### PR TITLE
Shows an error popup if there is no TTS

### DIFF
--- a/examples/text2speech/main.py
+++ b/examples/text2speech/main.py
@@ -25,4 +25,4 @@ class ErrorPopup(Popup):
 
 if __name__ == '__main__':
     Text2SpeechDemoApp().run()
-
+    

--- a/examples/text2speech/text2speechdemo.kv
+++ b/examples/text2speech/text2speechdemo.kv
@@ -29,3 +29,4 @@
             text: 'Dismiss'
             size_hint_y: 0.4
             on_press: root.dismiss()
+            


### PR DESCRIPTION
I have added code to show an error popup if the TTS facade is not implemented on a particular platform as requested in https://github.com/kivy/plyer/pull/37#issuecomment-37400827.
