### PR TITLE
add Windows email support

### DIFF
--- a/plyer/platforms/win/email.py
+++ b/plyer/platforms/win/email.py
@@ -21,7 +21,10 @@ class WindowsEmail(Email):
             uri += "body="
             uri += quote(str(text))
 
-        os.startfile(uri)
+        try:
+            os.startfile(uri)
+        except WindowsError:
+            print "Warning: unable to find a program able to send emails."
 
 
 def instance():


### PR DESCRIPTION
Note: I haven't tried it as I don't have Windows. I simply replaced the "xdg-open" part from my linux implementation with what I found here, line 94:
http://code.activestate.com/recipes/511443-cross-platform-startfile-and-mailto-functions/
