### PR TITLE
add Mac OS X email support

### DIFF
--- a/plyer/platforms/macosx/email.py
+++ b/plyer/platforms/macosx/email.py
@@ -1,0 +1,28 @@
+import subprocess
+from urllib import quote
+from plyer.facades import Email
+
+class MacOSXEmail(Email):
+    def _send(self, **kwargs):
+        recipient = kwargs.get('recipient')
+        subject = kwargs.get('subject')
+        text = kwargs.get('text')
+        create_chooser = kwargs.get('create_chooser')
+
+        uri = "mailto:"
+        if recipient:
+            uri += str(recipient)
+        if subject:
+            uri += "?" if not "?" in uri else "&"
+            uri += "subject="
+            uri += quote(str(subject))
+        if text:
+            uri += "?" if not "?" in uri else "&"
+            uri += "body="
+            uri += quote(str(text))
+
+        subprocess.Popen(["open", uri])
+
+
+def instance():
+    return MacOSXEmail()


### PR DESCRIPTION
I haven't tested this header. "open" should behave the same way as "xdg-open" on Linux, so it should work out of the box.
