### PR TITLE
Linux platform check made compatible with python 3.3+ (Fixes #58)

### DIFF
--- a/plyer/utils.py
+++ b/plyer/utils.py
@@ -35,7 +35,7 @@ def _determine_platform():
         return 'win'
     elif _sys_platform in ('darwin', ):
         return 'macosx'
-    elif _sys_platform in ('linux2', 'linux3'):
+    elif _sys_platform.startswith('linux'):
         return 'linux'
     return 'unknown'
 


### PR DESCRIPTION
Fixing as recommended by the python3 docs - sys.platform was changed to 'linux' in v3.3

https://docs.python.org/3.4/library/sys.html#sys.platform
