### PR TITLE
Add filechooser facade and support for Linux and Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,4 +32,5 @@ Compass                            X             X             X
 Unique ID (IMEI or SN)             X             X             X   X       X   X
 Gyroscope                          X             X             X
 Battery                            X             X             X   X       X   X
+Native file chooser                                                X           X
 ================================== ============= ============= === ======= === =====

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -6,7 +6,7 @@ Plyer
 
 __all__ = ('accelerometer', 'camera', 'gps', 'notification',
             'tts', 'email', 'vibrator', 'sms', 'compass',
-            'gyroscope', 'uniqueid', 'battery')
+            'gyroscope', 'uniqueid', 'battery', 'filechooser')
 
 __version__ = '1.2.1'
 
@@ -60,3 +60,7 @@ uniqueid = Proxy(
 #: Battery proxy to :class:`plyer.facades.Battery`
 battery = Proxy(
     'battery', facades.Battery)
+
+#: FileChooser proxy to :class:`plyer.facades.FileChooser`
+filechooser = Proxy(
+    'filechooser', facades.FileChooser)

--- a/plyer/facades.py
+++ b/plyer/facades.py
@@ -8,7 +8,7 @@ Interface of all the features available.
 
 __all__ = ('Accelerometer', 'Camera', 'GPS', 'Notification',
            'TTS', 'Email', 'Vibrator', 'Sms', 'Compass',
-           'Gyroscope', 'UniqueID', 'Battery')
+           'Gyroscope', 'UniqueID', 'Battery', 'FileChooser')
 
 
 class Accelerometer(object):
@@ -422,3 +422,81 @@ class Battery(object):
 
     def _get_state(self):
         raise NotImplementedError()
+
+
+class Battery(object):
+    '''Battery info facade.'''
+
+    @property
+    def status(self):
+        '''Property that contains a dict with the following fields:
+             * **isCharging** *(bool)*: Battery is charging
+             * **percentage** *(float)*: Battery charge remaining
+
+            .. warning::
+                If any of the fields is not readable, it is set as
+                None.
+        '''
+        return self.get_state()
+
+    def get_state(self):
+        return self._get_state()
+
+    #private
+
+    def _get_state(self):
+        raise NotImplementedError()
+
+class FileChooser(object):
+    '''Native filechooser dialog facade.
+
+    open_file, save_file and choose_dir accept a number of arguments
+    listed below. They return either a list of paths (normally
+    absolute), or None if no file was selected or the operation was
+    canceled and no result is available.
+
+    Arguments:
+        * **path** *(string or None)*: a path that will be selected
+            by default, or None
+        * **multiple** *(bool)*: True if you want the dialog to
+            allow multiple file selection. (Note: Windows doesn't
+            support multiple directory selection)
+        * **filters** *(iterable)*: either a list of wildcard patterns
+            or of sequences that contain the name of the filter and any
+            number of wildcards that will be grouped under that name
+            (e.g. [["Music", "*mp3", "*ogg", "*aac"], "*jpg", "*py"])
+        * **preview** *(bool)*: True if you want the file chooser to
+            show a preview of the selected file, if supported by the
+            back-end.
+        * **title** *(string or None)*: The title of the file chooser
+            window, or None for the default title.
+        * **icon** *(string or None)*: Path to the icon of the file
+            chooser window (where supported), or None for the back-end's
+            default.
+        * **show_hidden** *(bool)*: Force showing hidden files (currently
+            supported only on Windows)
+
+    Important: these methods will return only after user interaction.
+    Use threads or you will stop the mainloop if your app has one.
+    '''
+
+    def _file_selection_dialog(self, **kwargs):
+        raise NotImplementedError()
+
+    def open_file(self, *args, **kwargs):
+        """Open the file chooser in "open" mode.
+        """
+        return self._file_selection_dialog(mode="open", *args, **kwargs)
+
+    def save_file(self, *args, **kwargs):
+        """Open the file chooser in "save" mode. Confirmation will be asked
+        when a file with the same name already exists.
+        """
+        return self._file_selection_dialog(mode="save", *args, **kwargs)
+
+    def choose_dir(self, *args, **kwargs):
+        """Open the directory chooser. Note that on Windows this is very
+        limited. Consider writing your own chooser if you target that
+        platform and are planning on using unsupported features.
+        """
+        return self._file_selection_dialog(mode="dir", *args, **kwargs)

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -1,0 +1,216 @@
+'''
+Linux file chooser
+------------------
+'''
+
+from plyer.facades import FileChooser
+from distutils.spawn import find_executable as which
+import os
+import subprocess as sp
+import time
+
+
+class SubprocessFileChooser(object):
+    """A file chooser implementation that allows using
+    subprocess back-ends.
+    Normally you only need to override _gen_cmdline, executable,
+    separator and successretcode.
+    """
+
+    executable = ""
+    """The name of the executable of the back-end.
+    """
+
+    separator = "|"
+    """The separator used by the back-end. Override this for automatic
+    splitting, or override _split_output.
+    """
+
+    successretcode = 0
+    """The return code which is returned when the user doesn't close the
+    dialog without choosing anything, or when the app doesn't crash.
+    """
+
+    path = None
+    multiple = False
+    filters = []
+    preview = False
+    title = None
+    icon = None
+    show_hidden = False
+
+    def __init__(self, **kwargs):
+        # Simulate Kivy's behavior
+        for i in kwargs:
+            setattr(self, i, kwargs[i])
+
+    _process = None
+
+    def _run_command(self, cmd):
+        self._process = sp.Popen(cmd, stdout=sp.PIPE)
+        while True:
+            ret = self._process.poll()
+            if ret != None:
+                if ret == self.successretcode:
+                    out = self._process.communicate()[0].strip()
+                    self.selection = self._split_output(out)
+                    return self.selection
+                else:
+                    return None
+            time.sleep(0.1)
+
+    def _split_output(self, out):
+        """This methods receives the output of the back-end and turns
+        it into a list of paths.
+        """
+        return out.split(self.separator)
+
+    def _gen_cmdline(self):
+        """Returns the command line of the back-end, based on the current
+        properties. You need to override this.
+        """
+        raise NotImplementedError()
+
+    def run(self):
+        return self._run_command(self._gen_cmdline())
+
+
+class ZenityFileChooser(SubprocessFileChooser):
+    """A FileChooser implementation using Zenity (on GNU/Linux).
+
+    Not implemented features:
+    * show_hidden
+    * preview
+    """
+
+    executable = "zenity"
+    separator = "|"
+    successretcode = 0
+
+    def _gen_cmdline(self):
+        cmdline = [which(self.executable), "--file-selection", "--confirm-overwrite"]
+        if self.multiple:
+            cmdline += ["--multiple"]
+        if self.mode == "save":
+            cmdline += ["--save"]
+        elif self.mode == "dir":
+            cmdline += ["--directory"]
+        if self.path:
+            cmdline += ["--filename", self.path]
+        if self.title:
+             cmdline += ["--name", self.title]
+        if self.icon:
+            cmdline += ["--window-icon", self.icon]
+        for f in self.filters:
+            if type(f) == str:
+                cmdline += ["--file-filter", f]
+            else:
+                cmdline += ["--file-filter", "{name} | {flt}".format(name=f[0], flt=" ".join(f[1:]))]
+        return cmdline
+
+class KDialogFileChooser(SubprocessFileChooser):
+    """A FileChooser implementation using KDialog (on GNU/Linux).
+
+    Not implemented features:
+    * show_hidden
+    * preview
+    """
+
+    executable = "kdialog"
+    separator = "\n"
+    successretcode = 0
+
+    def _gen_cmdline(self):
+        cmdline = [which(self.executable)]
+
+        filt = []
+
+        for f in self.filters:
+            if type(f) == str:
+                filt += [f]
+            else:
+                filt += list(f[1:])
+
+        if self.mode == "dir":
+            cmdline += ["--getexistingdirectory", (self.path if self.path else os.path.expanduser("~"))]
+        elif self.mode == "save":
+            cmdline += ["--getopenfilename", (self.path if self.path else os.path.expanduser("~")), " ".join(filt)]
+        else:
+            cmdline += ["--getopenfilename", (self.path if self.path else os.path.expanduser("~")), " ".join(filt)]
+        if self.multiple:
+            cmdline += ["--multiple", "--separate-output"]
+        if self.title:
+            cmdline += ["--title", self.title]
+        if self.icon:
+            cmdline += ["--icon", self.icon]
+        return cmdline
+
+class YADFileChooser(SubprocessFileChooser):
+    """A NativeFileChooser implementation using YAD (on GNU/Linux).
+
+    Not implemented features:
+    * show_hidden
+    """
+
+    executable = "yad"
+    separator = "|?|"
+    successretcode = 0
+
+    def _gen_cmdline(self):
+        cmdline = [which(self.executable), "--file-selection", "--confirm-overwrite", "--geometry", "800x600+150+150"]
+        if self.multiple:
+            cmdline += ["--multiple", "--separator", self.separator]
+        if self.mode == "save":
+            cmdline += ["--save"]
+        elif self.mode == "dir":
+            cmdline += ["--directory"]
+        if self.preview:
+            cmdline += ["--add-preview"]
+        if self.path:
+            cmdline += ["--filename", self.path]
+        if self.title:
+             cmdline += ["--name", self.title]
+        if self.icon:
+            cmdline += ["--window-icon", self.icon]
+        for f in self.filters:
+            if type(f) == str:
+                cmdline += ["--file-filter", f]
+            else:
+                cmdline += ["--file-filter", "{name} | {flt}".format(name=f[0], flt=" ".join(f[1:]))]
+        return cmdline
+
+CHOOSERS = {"gnome":     ZenityFileChooser,
+            "kde":       KDialogFileChooser,
+            "yad":       YADFileChooser}
+
+class LinuxFileChooser(FileChooser):
+    """FileChooser implementation for GNu/Linux. Accepts one additional
+    keyword argument, *desktop_override*, which, if set, overrides the
+    back-end that will be used. Set it to "gnome" for Zenity, to "kde"
+    for KDialog and to "yad" for YAD (Yet Another Dialog).
+    If set to None or not set, a default one will be picked based on
+    the running desktop environment and installed back-ends.
+    """
+
+    desktop = None
+    if str(os.environ.get("XDG_CURRENT_DESKTOP")).lower() == "kde" and which("kdialog"):
+        desktop = "kde"
+    elif which("yad"):
+        desktop = "yad"
+    elif which("zenity"):
+        desktop = "gnome"
+
+    def _file_selection_dialog(self, desktop_override=desktop, **kwargs):
+        if not desktop_override:
+            desktop_override = desktop
+        # This means we couldn't find any back-end
+        if not desktop_override:
+            raise OSError("No back-end available. Please install one.")
+
+        chooser = CHOOSERS[desktop_override]
+        c = chooser(**kwargs)
+        return c.run()
+
+
+def instance():
+    return LinuxFileChooser()

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -1,0 +1,102 @@
+'''
+Windows file chooser
+--------------------
+'''
+
+from plyer.facades import FileChooser
+from win32com.shell import shell, shellcon
+import os
+import win32gui, win32con, pywintypes
+
+
+class Win32FileChooser(NativeFileChooserBase):
+    """A native implementation of NativeFileChooser using the
+    Win32 API on Windows.
+
+    Not Implemented features (all dialogs):
+    * preview
+    * icon
+
+    Not implemented features (in directory selection only - it's limited
+    by Windows itself):
+    * preview
+    * window-icon
+    * multiple
+    * show_hidden
+    * filters
+    * path
+    """
+
+    path = None
+    multiple = False
+    filters = []
+    preview = False
+    title = None
+    icon = None
+    show_hidden = False
+
+    def __init__(self, **kwargs):
+        # Simulate Kivy's behavior
+        for i in kwargs:
+            setattr(self, i, kwargs[i])
+
+    def run(self):
+        try:
+            if mode != "dir":
+                args = {}
+
+                if self.path:
+                    atgs["InitialDir"] = os.path.dirname(self.path)
+                    args["File"] = os.path.splitext(os.path.dirname(self.path))[0]
+                    args["DefExt"] = os.path.splitext(os.path.dirname(self.path))[1]
+                args["Title"] = self.title if self.title else "Pick a file..."
+                args["CustomFilter"] = 'Other file types\x00*.*\x00'
+                args["FilterIndex"] = 1
+
+                filters = ""
+                for f in self.filters:
+                    if type(f) == str:
+                        filters += (f + "\x00") * 2
+                    else:
+                        filters += f[0] + "\x00" + ";".join(f[1:]) + "\x00"
+                args["Filter"] = filters
+
+                flags = win32con.OFN_EXTENSIONDIFFERENT | win32con.OFN_OVERWRITEPROMPT
+                if self.multiple:
+                    flags |= win32con.OFN_ALLOWmultiple | win32con.OFN_EXPLORER
+                if self.show_hidden:
+                    flags |= win32con.OFN_FORCESHOWHIDDEN
+                args["Flags"] = flags
+
+                if self.mode == "open":
+                    self.fname, self.customfilter, self.flags = win32gui.GetOpenFileNameW(**args)
+                elif self.mode == "save":
+                    self.fname, self.customfilter, self.flags = win32gui.GetSaveFileNameW(**args)
+
+                if self.fname:
+                    if self.multiple:
+                        seq = str(self.fname).split("\x00")
+                        dir_n, base_n = seq[0], seq[1:]
+                        self.selection = [os.path.join(dir_n, i) for i in base_n]
+                    else:
+                        self.selection = str(self.fname).split("\x00")
+            else:
+                # From http://timgolden.me.uk/python/win32_how_do_i/browse-for-a-folder.html
+                pidl, display_name, image_list = shell.SHBrowseForFolder(
+                win32gui.GetDesktopWindow(), None,
+                self.title if self.title else "Pick a folder...", 0, None, None)
+                self.selection = [str(shell.SHGetPathFromIDList (pidl))]
+
+            return self.selection
+        except (RuntimeError, pywintypes.error):
+            return None
+
+class WinFileChooser(FileChooser):
+    """FileChooser implementation for Windows, using win3all.
+    """
+    def _file_selection_dialog(self, **kwargs):
+        return Win32FileChooser(**kwargs).run()
+
+
+def instance():
+    return WinFileChooser()


### PR DESCRIPTION
This adds another alternative implementation of native file chooser dialogs, and implementations for Windows (using win32all) and Linux (using either YAD, Zenity or KDialog, based on which one is installed and what desktop environment is running).