### PR TITLE
Android gps.py: fixed location provider cycling

### DIFF
--- a/plyer/platforms/android/gps.py
+++ b/plyer/platforms/android/gps.py
@@ -65,7 +65,7 @@ class AndroidGPS(GPS):
         providers = self._location_manager.getProviders(False).toArray()
         for provider in providers:
             self._location_manager.requestLocationUpdates(
-                "gps",
+                provider,
                 1000,  # minTime, in milliseconds
                 1,  # minDistance, in meters
                 self._location_listener,


### PR DESCRIPTION
Issue was first brought to light here: https://github.com/kivy/plyer/issues/54

GPS module was cycling through "gps" three times instead of all location services.