### PR TITLE
fix #107 - Use Android_ID instead of IMEI

### DIFF
--- a/plyer/facades/uniqueid.py
+++ b/plyer/facades/uniqueid.py
@@ -3,15 +3,14 @@ class UniqueID(object):
 
     Returns the following depending on the platform:
 
-    * **Android**: IMEI
+    * **Android**: Android ID
     * **Mac OSX**: Serial number of the device
     * **Linux**: Serial number using lshw
     * **Windows**: MachineGUID from regkey
-
-    .. note::
-        On Android your app needs the READ_PHONE_STATE permission
-
+    
     .. versionadded:: 1.2.0
+
+    .. versionchanged:: 1.2.4 On Android returns Android ID instead of IMEI
     '''
 
     @property

--- a/plyer/platforms/android/uniqueid.py
+++ b/plyer/platforms/android/uniqueid.py
@@ -1,17 +1,14 @@
-from jnius import autoclass, cast
+from jnius import autoclass
 from plyer.platforms.android import activity
 from plyer.facades import UniqueID
 
-TelephonyManager = autoclass('android.telephony.TelephonyManager')
-Context = autoclass('android.content.Context')
-
+Secure = autoclass('android.provider.Settings$Secure')
 
 class AndroidUniqueID(UniqueID):
 
     def _get_uid(self):
-        manager = cast('android.telephony.TelephonyManager',
-            activity.getSystemService(Context.TELEPHONY_SERVICE))
-        return manager.getDeviceId()
+        return Secure.getString(activity.getContentResolver(),
+                              Secure.ANDROID_ID)
 
 
 def instance():


### PR DESCRIPTION
Using Android_ID. 
Do I need to add something else?
