### PR TITLE
Add rotation sensor

### DIFF
--- a/examples/rotation/buildozer.spec
+++ b/examples/rotation/buildozer.spec
@@ -1,0 +1,173 @@
+[app]
+
+# (str) Title of your application
+title = Kivy Rotation
+
+# (str) Package name
+package.name = rotationexample
+
+# (str) Package domain (needed for android/ios packaging)
+package.domain = org.test
+
+# (str) Source code where the main.py live
+source.dir = .
+
+# (list) Source files to include (let empty to include all the files)
+source.include_exts = py,png,jpg,kv,atlas
+
+# (list) Source files to exclude (let empty to not exclude anything)
+#source.exclude_exts = spec
+
+# (list) List of directory to exclude (let empty to not exclude anything)
+#source.exclude_dirs = tests, bin
+
+# (list) List of exclusions using pattern matching
+#source.exclude_patterns = license,images/*/*.jpg
+
+# (str) Application versioning (method 1)
+# version.regex = __version__ = '(.*)'
+# version.filename = %(source.dir)s/main.py
+
+# (str) Application versioning (method 2)
+version = 1.0
+
+# (list) Application requirements
+requirements = plyer,kivy
+
+# (str) Presplash of the application
+#presplash.filename = %(source.dir)s/data/presplash.png
+
+# (str) Icon of the application
+#icon.filename = %(source.dir)s/data/icon.png
+
+# (str) Supported orientation (one of landscape, portrait or all)
+orientation = portrait
+
+# (bool) Indicate if the application should be fullscreen or not
+fullscreen = 0
+
+
+#
+# Android specific
+#
+
+# (list) Permissions
+# android.permissions = android.hardware.sensor.accelerometer
+
+# (int) Android API to use
+#android.api = 14
+
+# (int) Minimum API required (8 = Android 2.2 devices)
+#android.minapi = 8
+
+# (int) Android SDK version to use
+#android.sdk = 21
+
+# (str) Android NDK version to use
+#android.ndk = 9
+
+# (bool) Use --private data storage (True) or --dir public storage (False)
+#android.private_storage = True
+
+# (str) Android NDK directory (if empty, it will be automatically downloaded.)
+#android.ndk_path =
+
+# (str) Android SDK directory (if empty, it will be automatically downloaded.)
+#android.sdk_path = 
+
+# (str) Android entry point, default is ok for Kivy-based app
+#android.entrypoint = org.renpy.android.PythonActivity
+
+# (list) List of Java .jar files to add to the libs so that pyjnius can access
+# their classes. Don't add jars that you do not need, since extra jars can slow
+# down the build process. Allows wildcards matching, for example:
+# OUYA-ODK/libs/*.jar
+#android.add_jars = foo.jar,bar.jar,path/to/more/*.jar
+
+# (list) List of Java files to add to the android project (can be java or a
+# directory containing the files)
+#android.add_src =
+
+# (str) python-for-android branch to use, if not master, useful to try
+# not yet merged features.
+#android.branch = master
+
+# (str) OUYA Console category. Should be one of GAME or APP
+# If you leave this blank, OUYA support will not be enabled
+#android.ouya.category = GAME
+
+# (str) Filename of OUYA Console icon. It must be a 732x412 png image.
+#android.ouya.icon.filename = %(source.dir)s/data/ouya_icon.png
+
+# (str) XML file to include as an intent filters in <activity> tag
+#android.manifest.intent_filters = 
+
+# (list) Android additionnal libraries to copy into libs/armeabi
+#android.add_libs_armeabi = libs/android/*.so
+
+# (bool) Indicate whether the screen should stay on
+# Don't forget to add the WAKE_LOCK permission if you set this to True
+#android.wakelock = False
+
+# (list) Android application meta-data to set (key=value format)
+#android.meta_data =
+
+# (list) Android library project to add (will be added in the
+# project.properties automatically.)
+#android.library_references =
+
+#
+# iOS specific
+#
+
+# (str) Name of the certificate to use for signing the debug version
+# Get a list of available identities: buildozer ios list_identities
+#ios.codesign.debug = "iPhone Developer: <lastname> <firstname> (<hexstring>)"
+
+# (str) Name of the certificate to use for signing the release version
+#ios.codesign.release = %(ios.codesign.debug)s
+
+
+[buildozer]
+
+# (int) Log level (0 = error only, 1 = info, 2 = debug (with command output))
+log_level = 2
+
+
+# -----------------------------------------------------------------------------
+# List as sections
+# 
+# You can define all the "list" as [section:key].
+# Each line will be considered as a option to the list.
+# Let's take [app] / source.exclude_patterns.
+# Instead of doing:
+#
+#     [app]
+#     source.exclude_patterns = license,data/audio/*.wav,data/images/original/*
+#
+# This can be translated into:
+#
+#     [app:source.exclude_patterns]
+#     license
+#     data/audio/*.wav
+#     data/images/original/*
+#
+
+
+# -----------------------------------------------------------------------------
+# Profiles
+#
+# You can extend section / key with a profile
+# For example, you want to deploy a demo version of your application without
+# HD content. You could first change the title to add "(demo)" in the name
+# and extend the excluded directories to remove the HD content.
+#
+#     [app@demo]
+#     title = My Application (demo)
+#
+#     [app:source.exclude_patterns@demo]
+#     images/hd/*
+#
+# Then, invoke the command line with the "demo" profile:
+#
+#     buildozer --profile demo android debug

--- a/examples/rotation/main.py
+++ b/examples/rotation/main.py
@@ -1,0 +1,52 @@
+'''
+Rotation example.
+'''
+
+from kivy.app import App
+from kivy.uix.boxlayout import BoxLayout
+from kivy.clock import Clock
+
+from plyer import rotation
+
+
+class RotationTest(BoxLayout):
+    def __init__(self):
+        super(RotationTest, self).__init__()
+        self.sensorEnabled = False
+
+    def do_toggle(self):
+        try:
+            if not self.sensorEnabled:
+                rotation.enable()
+                Clock.schedule_interval(self.get_readings, 1 / 20.)
+
+                self.sensorEnabled = True
+                self.ids.toggle_button.text = "Stop rotation"
+            else:
+                rotation.disable()
+                Clock.unschedule(self.get_readings)
+
+                self.sensorEnabled = False
+                self.ids.toggle_button.text = "Start rotation"
+        except NotImplementedError:
+            import traceback
+
+            traceback.print_exc()
+            status = "Rotation is not implemented for your platform"
+            self.ids.status.text = status
+
+    def get_readings(self, dt):
+        val = rotation.rotation
+
+        self.ids.x_label.text = "Azimuth: " + str(val[0])
+        self.ids.y_label.text = "Picth: " + str(val[1])
+        self.ids.z_label.text = "Roll: " + str(val[2])
+
+
+class RotationTestApp(App):
+    def build(self):
+        return RotationTest()
+
+
+if __name__ == '__main__':
+    RotationTestApp().run()

--- a/examples/rotation/rotationtest.kv
+++ b/examples/rotation/rotationtest.kv
@@ -1,0 +1,30 @@
+#:kivy 1.8.0
+<RotationTest>:
+    BoxLayout:
+        orientation: 'vertical'
+
+        Label:
+            id: x_label
+            text: 'Azimuth: '
+
+        Label:
+            id: y_label
+            text: 'Pitch: '
+
+        Label:
+            id: z_label
+            text: 'Roll: '
+
+        Label:
+            id: status
+            text: ''
+
+        BoxLayout:
+            size_hint_y: None
+            height: '48dp'
+            padding: '4dp'
+
+            ToggleButton:
+                id: toggle_button
+                text: 'Start rotation'
+                on_press: root.do_toggle()

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -6,7 +6,7 @@ Plyer
 
 __all__ = ('accelerometer', 'audio', 'battery', 'camera', 'compass', 'email',
            'filechooser', 'gps', 'gyroscope', 'irblaster', 'orientation',
-           'notification', 'sms', 'tts', 'uniqueid', 'vibrator')
+           'notification', 'rotation', 'sms', 'tts', 'uniqueid', 'vibrator')
 
 __version__ = '1.2.5dev'
 
@@ -49,6 +49,9 @@ orientation = Proxy('orientation', facades.Orientation)
 
 #: Notification proxy to :class:`plyer.facades.Notification`
 notification = Proxy('notification', facades.Notification)
+
+#: Rotation proxy to :class:`plyer.facades.Rotation`
+rotation = Proxy('rotation', facades.Rotation)
 
 #: Sms proxy to :class:`plyer.facades.Sms`
 sms = Proxy('sms', facades.Sms)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -8,7 +8,7 @@ Interface of all the features available.
 
 __all__ = ('Accelerometer', 'Audio', 'Battery', 'Camera', 'Compass', 'Email',
            'FileChooser', 'GPS', 'Gyroscope', 'IrBlaster', 'Orientation',
-           'Notification', 'Sms', 'TTS', 'UniqueID', 'Vibrator')
+           'Notification', 'Rotation', 'Sms', 'TTS', 'UniqueID', 'Vibrator')
 
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
@@ -22,6 +22,7 @@ from plyer.facades.gyroscope import Gyroscope
 from plyer.facades.irblaster import IrBlaster
 from plyer.facades.orientation import Orientation
 from plyer.facades.notification import Notification
+from plyer.facades.rotation import Rotation
 from plyer.facades.sms import Sms
 from plyer.facades.tts import TTS
 from plyer.facades.uniqueid import UniqueID

--- a/plyer/facades/rotation.py
+++ b/plyer/facades/rotation.py
@@ -1,0 +1,52 @@
+class Rotation(object):
+    '''Rotation facade.
+
+    Rotation sensor is used to get the azimuth, pitch, and roll of the device.
+
+    Definition of the coordinate system used below :
+
+    X is defined as the vector product Y.Z (It is tangential to the ground at the device's current location and roughly
+    points East).
+    Y is tangential to the ground at the device's current location and points towards magnetic north.
+    Z points towards the sky and is perpendicular to the ground.
+
+    The rotation values IN DEGREES are given as a tuple :
+    values[0]: Azimuth, angle between the magnetic north direction and the y-axis, around the z-axis (0 to 359).
+    values[1]: Pitch, rotation around X-axis (-90 to 90), with positive values when the Z-axis moves toward the Y-axis
+    values[2]: Roll, rotation around the X-axis (-180 to 180) increasing as the device moves clockwise.
+
+
+    .. versionadded:: 1.2.5
+    '''
+
+    @property
+    def rotation(self):
+        '''Property that returns values of the current rotation
+        as (azimuth, pitch, roll) tuple.
+        Returns (None, None, None) if no data is currently available.
+        '''
+        return self.get_rotation()
+
+    def enable(self):
+        '''Activate the rotation sensor.
+        '''
+        self._enable()
+
+    def disable(self):
+        '''Disable the rotation sensor.
+        '''
+        self._disable()
+
+    def get_rotation(self):
+        return self._get_rotation()
+
+    # private
+
+    def _enable(self):
+        raise NotImplementedError()
+
+    def _disable(self):
+        raise NotImplementedError()
+
+    def _get_rotation(self):
+        raise NotImplementedError()

--- a/plyer/platforms/android/rotation.py
+++ b/plyer/platforms/android/rotation.py
@@ -1,0 +1,79 @@
+from plyer.facades import Rotation
+from jnius import PythonJavaClass, java_method, autoclass, cast
+from plyer.platforms.android import activity
+from math import pi
+
+Context = autoclass('android.content.Context')
+Sensor = autoclass('android.hardware.Sensor')
+SensorManager = autoclass('android.hardware.SensorManager')
+
+
+class RotationSensorListener(PythonJavaClass):
+    __javainterfaces__ = ['android/hardware/SensorEventListener']
+
+    def __init__(self):
+        super(RotationSensorListener, self).__init__()
+        self.SensorManager = cast('android.hardware.SensorManager',
+                                  activity.getSystemService(Context.SENSOR_SERVICE))
+        self.sensor = self.SensorManager.getDefaultSensor(
+            Sensor.TYPE_ROTATION_VECTOR)
+
+        # self.value = None
+        self.values = [None, None, None]
+        self.orientation = [0., 0., 0.]
+        self.rMat = [0.] * 9
+
+    def enable(self):
+        self.SensorManager.registerListener(self, self.sensor,
+                                            SensorManager.SENSOR_DELAY_NORMAL)
+
+    def disable(self):
+        self.SensorManager.unregisterListener(self, self.sensor)
+
+    @java_method('(Landroid/hardware/SensorEvent;)V')
+    def onSensorChanged(self, event):
+        SensorManager.getRotationMatrixFromVector(self.rMat, event.values[:3])
+        # values_ = [azimuth, pitch, roll]
+        values_ = SensorManager.getOrientation(self.rMat, self.orientation)[:3]
+        values_[0] = (values_[0] * 180 / pi + 360) % 360
+        values_[1] = values_[1] * 180 / pi
+        values_[2] = values_[2] * 180 / pi
+        self.values = values_
+
+    @java_method('(Landroid/hardware/Sensor;I)V')
+    def onAccuracyChanged(self, sensor, accuracy):
+        # Maybe, do something in future?
+        pass
+
+
+class AndroidRotation(Rotation):
+    def __init__(self):
+        super(AndroidRotation, self).__init__()
+        self.bState = False
+
+    def _enable(self):
+        if not self.bState:
+            self.listener = RotationSensorListener()
+            self.listener.enable()
+            self.bState = True
+
+    def _disable(self):
+        if self.bState:
+            self.bState = False
+            self.listener.disable()
+            del self.listener
+
+    def _get_rotation(self):
+        if self.bState:
+            return tuple(self.listener.values)
+        else:
+            return None, None, None
+
+    def __del__(self):
+        if self.bState:
+            self._disable()
+        super(self.__class__, self).__del__()
+
+
+def instance():
+    return AndroidRotation()


### PR DESCRIPTION
Add a sensor to get Azimuth (usefull for a compass), Pitch and Roll.
Uses high-level sensor (so called sensor fusion), to transparently use the accelerometer, gyroscope and magnetometer if they are available. It needs to initially orient itself and then eliminate the drift that comes with the gyroscope over time.
The data are stable and we have a great response time.