### PR TITLE
Note on requirements for iOS

### DIFF
--- a/plyer/facades/gps.py
+++ b/plyer/facades/gps.py
@@ -3,6 +3,12 @@ class GPS(object):
 
     .. versionadded:: 1.1
 
+    .. note::
+        On iOS `NSLocationWhenInUseUsageDescription` key is required for app to
+        display geolocation usage permission prompt. Key can be added in Xcode
+        target `info` section or in ``Resources/<YourApp>-info.plist``.
+        App background mode (`on_pause`) also must be supported.
+
     You need to set a `on_location` callback with the :meth:`configure` method.
     This callback will receive a couple of keywords / values, that might be
     different depending of their availability on the targeted platform.


### PR DESCRIPTION
Adding note for iOS-specific steps required to use GPS.
This is my first PR attempt, so please reply on any issues with it so I could learn and improve!

This note is based on comments in platform/ios/gps.py and practical tests with iphone 6s / Xcode 7.2.1
Also it could be related to https://github.com/kivy/plyer/issues/173 - in my case missing key lead to configure() passing without issues but on_location() never getting called. Thus location was never updated.
Regrettably I was unable to test it on simulators for iphones newer than iphone 5 (4s and 5 run GPS with lcation simulation just fine)