### PR TITLE
In-app browser: example, facade, and iOS naive implementation

### DIFF
--- a/examples/inappbrowser/buildozer.spec
+++ b/examples/inappbrowser/buildozer.spec
@@ -1,0 +1,173 @@
+[app]
+
+# (str) Title of your application
+title = Plyer In-app browser Example
+
+# (str) Package name
+package.name = inappbrowser
+
+# (str) Package domain (needed for android/ios packaging)
+package.domain = org.test
+
+# (str) Source code where the main.py live
+source.dir = .
+
+# (list) Source files to include (let empty to include all the files)
+source.include_exts = py,png,jpg,kv,atlas
+
+# (list) Source files to exclude (let empty to not exclude anything)
+#source.exclude_exts = spec
+
+# (list) List of directory to exclude (let empty to not exclude anything)
+#source.exclude_dirs = tests, bin
+
+# (list) List of exclusions using pattern matching
+#source.exclude_patterns = license,images/*/*.jpg
+
+# (str) Application versioning (method 1)
+# version.regex = __version__ = '(.*)'
+# version.filename = %(source.dir)s/main.py
+
+# (str) Application versioning (method 2)
+version = 1.0
+
+# (list) Application requirements
+requirements = plyer,kivy
+
+# (str) Presplash of the application
+#presplash.filename = %(source.dir)s/data/presplash.png
+
+# (str) Icon of the application
+#icon.filename = %(source.dir)s/data/icon.png
+
+# (str) Supported orientation (one of landscape, portrait or all)
+orientation = portrait
+
+# (bool) Indicate if the application should be fullscreen or not
+fullscreen = 0
+
+
+#
+# Android specific
+#
+
+# (list) Permissions
+#android.permissions = INTERNET
+
+# (int) Android API to use
+#android.api = 14
+
+# (int) Minimum API required (8 = Android 2.2 devices)
+#android.minapi = 8
+
+# (int) Android SDK version to use
+#android.sdk = 21
+
+# (str) Android NDK version to use
+#android.ndk = 9
+
+# (bool) Use --private data storage (True) or --dir public storage (False)
+#android.private_storage = True
+
+# (str) Android NDK directory (if empty, it will be automatically downloaded.)
+#android.ndk_path =
+
+# (str) Android SDK directory (if empty, it will be automatically downloaded.)
+#android.sdk_path = 
+
+# (str) Android entry point, default is ok for Kivy-based app
+#android.entrypoint = org.renpy.android.PythonActivity
+
+# (list) List of Java .jar files to add to the libs so that pyjnius can access
+# their classes. Don't add jars that you do not need, since extra jars can slow
+# down the build process. Allows wildcards matching, for example:
+# OUYA-ODK/libs/*.jar
+#android.add_jars = foo.jar,bar.jar,path/to/more/*.jar
+
+# (list) List of Java files to add to the android project (can be java or a
+# directory containing the files)
+#android.add_src =
+
+# (str) python-for-android branch to use, if not master, useful to try
+# not yet merged features.
+#android.branch = master
+
+# (str) OUYA Console category. Should be one of GAME or APP
+# If you leave this blank, OUYA support will not be enabled
+#android.ouya.category = GAME
+
+# (str) Filename of OUYA Console icon. It must be a 732x412 png image.
+#android.ouya.icon.filename = %(source.dir)s/data/ouya_icon.png
+
+# (str) XML file to include as an intent filters in <activity> tag
+#android.manifest.intent_filters = 
+
+# (list) Android additionnal libraries to copy into libs/armeabi
+#android.add_libs_armeabi = libs/android/*.so
+
+# (bool) Indicate whether the screen should stay on
+# Don't forget to add the WAKE_LOCK permission if you set this to True
+#android.wakelock = False
+
+# (list) Android application meta-data to set (key=value format)
+#android.meta_data =
+
+# (list) Android library project to add (will be added in the
+# project.properties automatically.)
+#android.library_references =
+
+#
+# iOS specific
+#
+
+# (str) Name of the certificate to use for signing the debug version
+# Get a list of available identities: buildozer ios list_identities
+#ios.codesign.debug = "iPhone Developer: <lastname> <firstname> (<hexstring>)"
+
+# (str) Name of the certificate to use for signing the release version
+#ios.codesign.release = %(ios.codesign.debug)s
+
+
+[buildozer]
+
+# (int) Log level (0 = error only, 1 = info, 2 = debug (with command output))
+log_level = 2
+
+
+# -----------------------------------------------------------------------------
+# List as sections
+# 
+# You can define all the "list" as [section:key].
+# Each line will be considered as a option to the list.
+# Let's take [app] / source.exclude_patterns.
+# Instead of doing:
+#
+#     [app]
+#     source.exclude_patterns = license,data/audio/*.wav,data/images/original/*
+#
+# This can be translated into:
+#
+#     [app:source.exclude_patterns]
+#     license
+#     data/audio/*.wav
+#     data/images/original/*
+#
+
+
+# -----------------------------------------------------------------------------
+# Profiles
+#
+# You can extend section / key with a profile
+# For example, you want to deploy a demo version of your application without
+# HD content. You could first change the title to add "(demo)" in the name
+# and extend the excluded directories to remove the HD content.
+#
+#     [app@demo]
+#     title = My Application (demo)
+#
+#     [app:source.exclude_patterns@demo]
+#     images/hd/*
+#
+# Then, invoke the command line with the "demo" profile:
+#
+#     buildozer --profile demo android debug

--- a/examples/inappbrowser/main.py
+++ b/examples/inappbrowser/main.py
@@ -1,0 +1,47 @@
+
+from kivy.app import App
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.button import Button
+from kivy.lang import Builder
+from kivy.properties import StringProperty
+
+from plyer import inappbrowser
+
+Builder.load_string('''
+<InAppBrowserInterface>:
+    orientation: 'vertical'
+    Label:
+        id: label
+        text: 'Input URL below to go'
+    TextInput:
+        id: address
+        text: 'https://www.github.com'
+    IntentButton:
+        url_text: address.text
+        text: 'Go'
+        size_hint_y: None
+        height: sp(40)
+        on_release: self.go()
+''')
+
+
+class InAppBrowserInterface(BoxLayout):
+    pass
+
+
+class IntentButton(Button):
+    url_text = StringProperty()
+
+    def go(self, *args):
+        inappbrowser.open_url(url=self.url_text)
+
+
+class InAppBrowserApp(App):
+    def build(self):
+        return InAppBrowserInterface()
+
+    def on_pause(self):
+        return True
+
+if __name__ == "__main__":
+    InAppBrowserApp().run()

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -6,7 +6,7 @@ Plyer
 
 __all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
            'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
-           'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator')
+           'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator', 'inappbrowser')
 
 __version__ = '1.2.5dev'
 
@@ -67,3 +67,5 @@ vibrator = Proxy('vibrator', facades.Vibrator)
 
 #: Flash proxy to :class:`plyer.facades.Flash`
 flash = Proxy('flash', facades.Flash)
+
+inappbrowser = Proxy('inappbrowser', facades.InAppBrowser)

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -6,7 +6,8 @@ Plyer
 
 __all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
            'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
-           'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator', 'inappbrowser')
+           'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator',
+           'inappbrowser')
 
 __version__ = '1.2.5dev'
 

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -69,4 +69,5 @@ vibrator = Proxy('vibrator', facades.Vibrator)
 #: Flash proxy to :class:`plyer.facades.Flash`
 flash = Proxy('flash', facades.Flash)
 
+#: InAppBrowser proxy to :class:`plyer.facades.InAppBrowser'
 inappbrowser = Proxy('inappbrowser', facades.InAppBrowser)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -9,7 +9,7 @@ Interface of all the features available.
 __all__ = ('Accelerometer', 'Audio', 'Battery', 'Call', 'Camera', 'Compass',
            'Email', 'FileChooser', 'GPS', 'Gyroscope', 'IrBlaster',
            'Orientation', 'Notification', 'Sms', 'TTS', 'UniqueID', 'Vibrator',
-           'Flash')
+           'Flash', 'InAppBrowser')
 
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
@@ -29,3 +29,4 @@ from plyer.facades.tts import TTS
 from plyer.facades.uniqueid import UniqueID
 from plyer.facades.vibrator import Vibrator
 from plyer.facades.flash import Flash
+from plyer.facades.inappbrowser import InAppBrowser

--- a/plyer/facades/inappbrowser.py
+++ b/plyer/facades/inappbrowser.py
@@ -1,0 +1,15 @@
+class InAppBrowser(object):
+    '''InAppBrowser facade.'''
+
+    def open_url(self, url=None):
+        '''Open an in-app webview to open given url.
+
+        :param url: url (str)
+
+        '''
+        self._open_url(url=url)
+
+    # private
+
+    def _open_url(self, **kwargs):
+        raise NotImplementedError()

--- a/plyer/platforms/ios/inappbrowser.py
+++ b/plyer/platforms/ios/inappbrowser.py
@@ -1,0 +1,27 @@
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
+from plyer.facades import InAppBrowser
+from pyobjus import autoclass, objc_str
+from pyobjus.dylib_manager import load_framework
+
+# load_framework('/System/Library/Frameworks/UIKit.framework')
+
+NSURL = autoclass('NSURL')
+NSString = autoclass('NSString')
+UIApplication = autoclass('UIApplication')
+
+
+class iOSInAppBrowser(InAppBrowser):
+    def _open_url(self, **kwargs):
+        url = kwargs.get('url', '')
+
+        nsurl = NSURL.alloc().initWithString_(objc_str(str(url)))
+
+        UIApplication.sharedApplication().openURL_(nsurl)
+
+
+def instance():
+    return iOSInAppBrowser()

--- a/plyer/platforms/ios/inappbrowser.py
+++ b/plyer/platforms/ios/inappbrowser.py
@@ -7,7 +7,7 @@ from plyer.facades import InAppBrowser
 from pyobjus import autoclass, objc_str
 from pyobjus.dylib_manager import load_framework
 
-# load_framework('/System/Library/Frameworks/UIKit.framework')
+load_framework('/System/Library/Frameworks/UIKit.framework')
 
 NSURL = autoclass('NSURL')
 NSString = autoclass('NSString')

--- a/plyer/platforms/macosx/notification.py
+++ b/plyer/platforms/macosx/notification.py
@@ -21,12 +21,14 @@ class OSXNotification(Notification):
         notification.setSubtitle_(objc_str(app_name))
         notification.setInformativeText_(objc_str(message))
 
-        userNotificationCenter = NSUserNotificationCenter.defaultUserNotificationCenter()
+        userNotificationCenter = NSUserNotificationCenter\
+            .defaultUserNotificationCenter()
         userNotificationCenter.setDelegate_(self)
         userNotificationCenter.deliverNotification_(notification)
 
     @protocol('NSUserNotificationCenterDelegate')
-    def userNotificationCenter_shouldPresentNotification_(self, center, notification):
+    def userNotificationCenter_shouldPresentNotification_(
+            self, center, notification):
         return ObjcBOOL(True)
 
 

--- a/plyer/platforms/macosx/notification.py
+++ b/plyer/platforms/macosx/notification.py
@@ -1,27 +1,34 @@
 from plyer.facades import Notification
-import Foundation
-import objc
-import AppKit
+from pyobjus import autoclass, protocol, objc_str, ObjcBOOL
+from pyobjus.dylib_manager import load_framework, INCLUDE
+
+load_framework(INCLUDE.AppKit)
+load_framework(INCLUDE.Foundation)
+
+NSUserNotification = autoclass('NSUserNotification')
+NSUserNotificationCenter = autoclass('NSUserNotificationCenter')
 
 
 class OSXNotification(Notification):
     def _notify(self, **kwargs):
-        NSUserNotification = objc.lookUpClass('NSUserNotification')
-        NSUserNotificationCenter = objc.lookUpClass('NSUserNotificationCenter')
+        title = kwargs.get('title', '')
+        message = kwargs.get('message', '')
+        app_name = kwargs.get('app_name', '')
+        # app_icon, timeout, ticker are not supported (yet)
+
         notification = NSUserNotification.alloc().init()
-        notification.setTitle_(kwargs.get('title').encode('utf-8'))
-        #notification.setSubtitle_(str(subtitle))
-        notification.setInformativeText_(kwargs.get('message').encode('utf-8'))
-        notification.setSoundName_("NSUserNotificationDefaultSoundName")
-        #notification.setHasActionButton_(False)
-        #notification.setOtherButtonTitle_("View")
-        #notification.setUserInfo_({"action":"open_url", "value":url})
-        NSUserNotificationCenter.defaultUserNotificationCenter() \
-                            .setDelegate_(self)
-        NSUserNotificationCenter.defaultUserNotificationCenter() \
-                            .scheduleNotification_(notification)
+        notification.setTitle_(objc_str(title))
+        notification.setSubtitle_(objc_str(app_name))
+        notification.setInformativeText_(objc_str(message))
+
+        userNotificationCenter = NSUserNotificationCenter.defaultUserNotificationCenter()
+        userNotificationCenter.setDelegate_(self)
+        userNotificationCenter.deliverNotification_(notification)
+
+    @protocol('NSUserNotificationCenterDelegate')
+    def userNotificationCenter_shouldPresentNotification_(self, center, notification):
+        return ObjcBOOL(True)
 
 
 def instance():
     return OSXNotification()
-

--- a/plyer/platforms/macosx/notification.py
+++ b/plyer/platforms/macosx/notification.py
@@ -1,36 +1,27 @@
 from plyer.facades import Notification
-from pyobjus import autoclass, protocol, objc_str, ObjcBOOL
-from pyobjus.dylib_manager import load_framework, INCLUDE
-
-load_framework(INCLUDE.AppKit)
-load_framework(INCLUDE.Foundation)
-
-NSUserNotification = autoclass('NSUserNotification')
-NSUserNotificationCenter = autoclass('NSUserNotificationCenter')
+import Foundation
+import objc
+import AppKit
 
 
 class OSXNotification(Notification):
     def _notify(self, **kwargs):
-        title = kwargs.get('title', '')
-        message = kwargs.get('message', '')
-        app_name = kwargs.get('app_name', '')
-        # app_icon, timeout, ticker are not supported (yet)
-
+        NSUserNotification = objc.lookUpClass('NSUserNotification')
+        NSUserNotificationCenter = objc.lookUpClass('NSUserNotificationCenter')
         notification = NSUserNotification.alloc().init()
-        notification.setTitle_(objc_str(title))
-        notification.setSubtitle_(objc_str(app_name))
-        notification.setInformativeText_(objc_str(message))
-
-        userNotificationCenter = NSUserNotificationCenter\
-            .defaultUserNotificationCenter()
-        userNotificationCenter.setDelegate_(self)
-        userNotificationCenter.deliverNotification_(notification)
-
-    @protocol('NSUserNotificationCenterDelegate')
-    def userNotificationCenter_shouldPresentNotification_(
-            self, center, notification):
-        return ObjcBOOL(True)
+        notification.setTitle_(kwargs.get('title').encode('utf-8'))
+        #notification.setSubtitle_(str(subtitle))
+        notification.setInformativeText_(kwargs.get('message').encode('utf-8'))
+        notification.setSoundName_("NSUserNotificationDefaultSoundName")
+        #notification.setHasActionButton_(False)
+        #notification.setOtherButtonTitle_("View")
+        #notification.setUserInfo_({"action":"open_url", "value":url})
+        NSUserNotificationCenter.defaultUserNotificationCenter() \
+                            .setDelegate_(self)
+        NSUserNotificationCenter.defaultUserNotificationCenter() \
+                            .scheduleNotification_(notification)
 
 
 def instance():
     return OSXNotification()
+


### PR DESCRIPTION
I made an attempt to implement a new feature, in-app browser. The in-app browser, as I know, is a view(, view controller, activity) to let user browser something within the app. It currently owns one simple method `open_url`, and more methods, properties can be added if our requirement grows.
The example app I designed contains only a text input for inputting url and a button. I don't know whether there is the concept 'in-app browser' on desktop, and I only implement it on iOS as a try. 
The implementation on iOS is naive, and actually it is not internal.

`UIApplication.sharedApplication().openURL_(nsurl)`

Anyway, I have tested it on iOS 9, iPad mini 2 and it works.

I have come up with how to implement it in a properer way, but a few things need to be done. Maybe I will do it in the next PR:
I want to import a third-party class, which can be easily used by PyOBJus. But I don't know if it is allowed to add new dependency for this feature.
As Apple restricts in-app HTTP request since iOS 9 [(ref),](http://stackoverflow.com/questions/31254725/transport-security-has-blocked-a-cleartext-http) info.plist needs a minor modification to allow a real in-app browser. I'm not sure if it is user-friendly.
