### PR TITLE
Py3 compatibility, open browser and edit sms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,9 @@ GPS                                X       X
 Notifications                      X           X       X    X
 Text to speech                     X       X   X       X    X
 Email (open mail client)           X       X   X       X    X
+Browser (open browser client)      X                        X
 Vibrator                           X       X
-Sms (send messages)                X
+Sms (send messages or open client) X
 Compass                            X       X
 Unique ID                          X       X   X       X    X
 Gyroscope                          X       X

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -4,7 +4,7 @@ Plyer
 
 '''
 
-__all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
+__all__ = ('accelerometer', 'audio', 'battery', 'browser', 'call', 'camera', 'compass',
            'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
            'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator')
 
@@ -22,6 +22,9 @@ audio = Proxy('audio', facades.Audio)
 
 #: Battery proxy to :class:`plyer.facades.Battery`
 battery = Proxy('battery', facades.Battery)
+
+#: Browser proxy to :class:`plyer.facades.Browser`
+browser = Proxy('browser', facades.Browser)
 
 #: Call proxy to  :class `plyer.facades.Call`
 call = Proxy('call', facades.Call)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -6,7 +6,7 @@ Interface of all the features available.
 
 '''
 
-__all__ = ('Accelerometer', 'Audio', 'Battery', 'Call', 'Camera', 'Compass',
+__all__ = ('Accelerometer', 'Audio', 'Battery', 'Browser', 'Call', 'Camera', 'Compass',
            'Email', 'FileChooser', 'GPS', 'Gyroscope', 'IrBlaster',
            'Orientation', 'Notification', 'Sms', 'TTS', 'UniqueID', 'Vibrator',
            'Flash')
@@ -14,6 +14,7 @@ __all__ = ('Accelerometer', 'Audio', 'Battery', 'Call', 'Camera', 'Compass',
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
 from plyer.facades.battery import Battery
+from plyer.facades.browser import Browser
 from plyer.facades.call import Call
 from plyer.facades.camera import Camera
 from plyer.facades.compass import Compass

--- a/plyer/facades/browser.py
+++ b/plyer/facades/browser.py
@@ -1,0 +1,13 @@
+class Browser(object):
+    '''Browser facade.
+    .. versionadded:: ???
+
+    '''
+
+    def open(self, uri):
+        self._open(uri=uri)
+
+    # private
+
+    def _open(self, **kwargs):
+        raise NotImplementedError()

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -5,6 +5,7 @@ class Sms(object):
 
         On Android your app needs the SEND_SMS permission in order to
         send sms messages.
+        It does not require any permission to use the edit method.
 
     .. versionadded:: 1.2.0
 
@@ -13,7 +14,13 @@ class Sms(object):
     def send(self, recipient, message):
         self._send(recipient=recipient, message=message)
 
+    def edit(self, recipient=None, message=None):
+        self._edit(recipient=recipient, message=message)
+
     # private
 
     def _send(self, **kwargs):
+        raise NotImplementedError()
+
+    def _edit(self, **kwargs):
         raise NotImplementedError()

--- a/plyer/platforms/android/__init__.py
+++ b/plyer/platforms/android/__init__.py
@@ -1,12 +1,28 @@
 from os import environ
 from jnius import autoclass
 
+__all__ = ['PythonService', 'PythonActivity', 'activity',
+           'ANDROID_VERSION', 'SDK_INT', 'USE_SDL2']
+
+# Determine whether SDL2 is used. if so, use PythonActivity provided by kivy
+try:
+    from kivy.setupconfig import USE_SDL2
+except ImportError:
+    USE_SDL2 = False
+
+if USE_SDL2:
+    clsname = 'org.kivy.android.PythonActivity'
+else:
+    clsname = 'org.renpy.android.PythonActivity'
+
+
 ANDROID_VERSION = autoclass('android.os.Build$VERSION')
 SDK_INT = ANDROID_VERSION.SDK_INT
 
 if 'PYTHON_SERVICE_ARGUMENT' in environ:
-    PythonService = autoclass('org.renpy.android.PythonService')
+    PythonService = autoclass(clsname)
     activity = PythonService.mService
 else:
-    PythonActivity = autoclass('org.renpy.android.PythonActivity')
+    PythonActivity = autoclass(clsname)
     activity = PythonActivity.mActivity
+

--- a/plyer/platforms/android/accelerometer.py
+++ b/plyer/platforms/android/accelerometer.py
@@ -5,7 +5,7 @@ Android accelerometer
 
 from plyer.facades import Accelerometer
 from jnius import PythonJavaClass, java_method, autoclass, cast
-from plyer.platforms.android import activity
+from . import activity
 
 Context = autoclass('android.content.Context')
 Sensor = autoclass('android.hardware.Sensor')

--- a/plyer/platforms/android/battery.py
+++ b/plyer/platforms/android/battery.py
@@ -1,5 +1,5 @@
 from jnius import autoclass, cast
-from plyer.platforms.android import activity
+from . import activity
 from plyer.facades import Battery
 
 Intent = autoclass('android.content.Intent')

--- a/plyer/platforms/android/browser.py
+++ b/plyer/platforms/android/browser.py
@@ -1,0 +1,21 @@
+'''
+Android Browser
+-----------
+'''
+
+from jnius import autoclass
+from plyer.facades import Browser
+from plyer.platforms.android import activity
+
+Intent = autoclass('android.content.Intent')
+uri = autoclass('android.net.Uri')
+
+class AndroidBrowser(Browser):
+    def _open(self, **kwargs):
+        intent = Intent(Intent.ACTION_VIEW)
+        uri = kwargs.get('uri')
+        intent.setData(uri.parse(uri))
+        activity.startActivity(intent)
+
+def instance():
+    return AndroidBrowser()

--- a/plyer/platforms/android/browser.py
+++ b/plyer/platforms/android/browser.py
@@ -5,7 +5,7 @@ Android Browser
 
 from jnius import autoclass
 from plyer.facades import Browser
-from plyer.platforms.android import activity
+from . import activity
 
 Intent = autoclass('android.content.Intent')
 uri = autoclass('android.net.Uri')

--- a/plyer/platforms/android/call.py
+++ b/plyer/platforms/android/call.py
@@ -5,7 +5,7 @@ Android Call
 
 from jnius import autoclass
 from plyer.facades import Call
-from plyer.platforms.android import activity
+from . import activity
 
 Intent = autoclass('android.content.Intent')
 uri = autoclass('android.net.Uri')

--- a/plyer/platforms/android/camera.py
+++ b/plyer/platforms/android/camera.py
@@ -1,12 +1,9 @@
-import android
-import android.activity
+from . import activity
 from os import unlink
 from jnius import autoclass, cast
 from plyer.facades import Camera
-from plyer.platforms.android import activity
 
 Intent = autoclass('android.content.Intent')
-PythonActivity = autoclass('org.renpy.android.PythonActivity')
 MediaStore = autoclass('android.provider.MediaStore')
 Uri = autoclass('android.net.Uri')
 
@@ -17,8 +14,8 @@ class AndroidCamera(Camera):
         assert(on_complete is not None)
         self.on_complete = on_complete
         self.filename = filename
-        android.activity.unbind(on_activity_result=self._on_activity_result)
-        android.activity.bind(on_activity_result=self._on_activity_result)
+        activity.unbind(on_activity_result=self._on_activity_result)
+        activity.bind(on_activity_result=self._on_activity_result)
         intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
         uri = Uri.parse('file://' + filename)
         parcelable = cast('android.os.Parcelable', uri)
@@ -29,8 +26,8 @@ class AndroidCamera(Camera):
         assert(on_complete is not None)
         self.on_complete = on_complete
         self.filename = filename
-        android.activity.unbind(on_activity_result=self._on_activity_result)
-        android.activity.bind(on_activity_result=self._on_activity_result)
+        activity.unbind(on_activity_result=self._on_activity_result)
+        activity.bind(on_activity_result=self._on_activity_result)
         intent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)
         uri = Uri.parse('file://' + filename)
         parcelable = cast('android.os.Parcelable', uri)
@@ -44,7 +41,7 @@ class AndroidCamera(Camera):
     def _on_activity_result(self, requestCode, resultCode, intent):
         if requestCode != 0x123:
             return
-        android.activity.unbind(on_activity_result=self._on_activity_result)
+        activity.unbind(on_activity_result=self._on_activity_result)
         if self.on_complete(self.filename):
             self._unlink(self.filename)
 

--- a/plyer/platforms/android/compass.py
+++ b/plyer/platforms/android/compass.py
@@ -5,7 +5,7 @@ Android Compass
 
 from plyer.facades import Compass
 from jnius import PythonJavaClass, java_method, autoclass, cast
-from plyer.platforms.android import activity
+from . import activity
 
 Context = autoclass('android.content.Context')
 Sensor = autoclass('android.hardware.Sensor')

--- a/plyer/platforms/android/email.py
+++ b/plyer/platforms/android/email.py
@@ -1,6 +1,6 @@
 from jnius import autoclass, cast
 from plyer.facades import Email
-from plyer.platforms.android import activity
+from . import activity
 
 Intent = autoclass('android.content.Intent')
 AndroidString = autoclass('java.lang.String')

--- a/plyer/platforms/android/flash.py
+++ b/plyer/platforms/android/flash.py
@@ -6,7 +6,7 @@ Flash
 
 from plyer.facades import Flash
 from jnius import autoclass
-from plyer.platforms.android import activity
+from . import activity
 
 Camera = autoclass("android.hardware.Camera")
 CameraParameters = autoclass("android.hardware.Camera$Parameters")

--- a/plyer/platforms/android/gps.py
+++ b/plyer/platforms/android/gps.py
@@ -4,7 +4,7 @@ Android GPS
 '''
 
 from plyer.facades import GPS
-from plyer.platforms.android import activity
+from . import activity
 from jnius import autoclass, java_method, PythonJavaClass
 
 Looper = autoclass('android.os.Looper')

--- a/plyer/platforms/android/gyroscope.py
+++ b/plyer/platforms/android/gyroscope.py
@@ -5,7 +5,7 @@ Android Gyroscope
 
 from plyer.facades import Gyroscope
 from jnius import PythonJavaClass, java_method, autoclass, cast
-from plyer.platforms.android import activity
+from . import activity
 
 Context = autoclass('android.content.Context')
 Sensor = autoclass('android.hardware.Sensor')

--- a/plyer/platforms/android/irblaster.py
+++ b/plyer/platforms/android/irblaster.py
@@ -1,7 +1,7 @@
 from jnius import autoclass
 
 from plyer.facades import IrBlaster
-from plyer.platforms.android import activity, SDK_INT, ANDROID_VERSION
+from . import activity, SDK_INT, ANDROID_VERSION
 
 if SDK_INT >= 19:
     Context = autoclass('android.content.Context')

--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -1,6 +1,6 @@
 from jnius import autoclass
 from plyer.facades import Notification
-from plyer.platforms.android import activity, SDK_INT
+from . import activity, SDK_INT
 
 AndroidString = autoclass('java.lang.String')
 Context = autoclass('android.content.Context')

--- a/plyer/platforms/android/orientation.py
+++ b/plyer/platforms/android/orientation.py
@@ -1,5 +1,5 @@
 from jnius import autoclass, cast
-from plyer.platforms.android import activity
+from . import activity
 from plyer.facades import Orientation
 
 ActivityInfo = autoclass('android.content.pm.ActivityInfo')

--- a/plyer/platforms/android/sms.py
+++ b/plyer/platforms/android/sms.py
@@ -5,9 +5,12 @@ Android SMS
 
 from jnius import autoclass
 from plyer.facades import Sms
+from . import activity
 
 SmsManager = autoclass('android.telephony.SmsManager')
 
+Intent = autoclass('android.content.Intent')
+uri = autoclass('android.net.Uri')
 
 class AndroidSms(Sms):
 
@@ -19,6 +22,27 @@ class AndroidSms(Sms):
 
         if sms:
             sms.sendTextMessage(recipient, None, message, None, None)
+
+    def _edit(self, **kwargs):
+        recipient = kwargs.get('recipient')
+        address = recipient or ""
+        message = kwargs.get('message')
+        sms_body = message or ""
+
+        if not address:
+            intent = Intent(Intent.ACTION_SEND)
+            intent.setType("text/plain")
+            intent.putExtra(Intent.EXTRA_TEXT, sms_body)
+            package = autoclass(
+                'android.provider.Telephony.Sms').getDefaultSmsPackage()
+            if package:
+                intent.setPackage(package)
+        else:
+            intent = Intent(Intent.ACTION_SENDTO)
+            intent.setData(uri.parse("smsto:" + uri.encode(address)))
+            intent.putExtra("sms_body", sms_body)
+
+        activity.startActivity(intent)
 
 
 def instance():

--- a/plyer/platforms/android/tts.py
+++ b/plyer/platforms/android/tts.py
@@ -1,7 +1,7 @@
 from time import sleep
 from jnius import autoclass
 from plyer.facades import TTS
-from plyer.platforms.android import activity
+from . import activity
 
 Locale = autoclass('java.util.Locale')
 TextToSpeech = autoclass('android.speech.tts.TextToSpeech')

--- a/plyer/platforms/android/uniqueid.py
+++ b/plyer/platforms/android/uniqueid.py
@@ -1,5 +1,5 @@
 from jnius import autoclass
-from plyer.platforms.android import activity
+from . import activity
 from plyer.facades import UniqueID
 
 Secure = autoclass('android.provider.Settings$Secure')

--- a/plyer/platforms/android/vibrator.py
+++ b/plyer/platforms/android/vibrator.py
@@ -2,8 +2,7 @@
 
 from jnius import autoclass
 from plyer.facades import Vibrator
-from plyer.platforms.android import activity
-from plyer.platforms.android import SDK_INT
+from . import activity, SDK_INT
 
 Context = autoclass('android.content.Context')
 vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)

--- a/plyer/platforms/linux/browser.py
+++ b/plyer/platforms/linux/browser.py
@@ -1,0 +1,21 @@
+import subprocess
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+from plyer.facades import Browser
+from plyer.utils import whereis_exe
+
+
+class LinuxBrowser(Browser):
+    def _open(self, **kwargs):
+        uri = kwargs.get('uri')
+        subprocess.Popen(["xdg-open", uri])
+
+
+def instance():
+    import sys
+    if whereis_exe('xdg-open'):
+        return LinuxBrowser()
+    sys.stderr.write("xdg-open not found.")
+    return Browser()

--- a/plyer/platforms/linux/email.py
+++ b/plyer/platforms/linux/email.py
@@ -1,5 +1,4 @@
 import subprocess
-from urllib import quote
 try:
     from urllib.parse import quote
 except ImportError:


### PR DESCRIPTION
Hi, I have several features in this PR

* I have fixed a bug that caused py3 to crash on android
* pyjnius calls to `PythonActivity` in have been redirected use `activity` from `android.__init__` where found. the autoclass of `PythonActivity` tries to use `kivy.setupconfig.USE_SDL2` to determine whether `org.renpy` or `org.kivy` should be used, as `org.renpy` is deprecated and can cause crashes.
 * Also note that imports from `plyer.platform.android.__init__` have been refactored to `from . import ...` as I find it much cleaner and futureproof. This can easily be changed back ;)
* A `Browser` has been implemented for linux and android. It just opens the platform native browser - useful for clicking links.
* An `edit` method has been added to `Sms` class for android. It opens the native SMS application and starts a message that can be populated with:
 * recipient
 * message
 * recipient _and_ message

I did not mean to bunch everything into a single PR. But I was just using it for my own application, and suddenly I had implemented several things I might as well share. Unless you guys have a problem with one or more of the features I'm not inclined to bother trying to separate them into individual PRs.

Regards 
Emil Lynge