### PR TITLE
Return screen orientation based on device natural rotation.

### DIFF
--- a/plyer/facades/orientation.py
+++ b/plyer/facades/orientation.py
@@ -8,7 +8,19 @@ class Orientation(object):
 
     .. versionadded:: 1.2.4
     '''
-
+    @property
+    def orientation(self):
+        '''Property that returns values of the current screen orientation, 
+        relative to the natural orientation of the device (tablet or smartphone).
+        '''
+        return self.get_orientation()
+        
+    def get_orientation(self):
+        return self._get_orientation()
+        
+    def _get_orientation(self):
+        raise NotImplementedError()
+        
     def set_landscape(self, reverse=False):
         '''Rotate the app to a landscape orientation.
 

--- a/plyer/platforms/android/orientation.py
+++ b/plyer/platforms/android/orientation.py
@@ -3,7 +3,8 @@ from plyer.platforms.android import activity
 from plyer.facades import Orientation
 
 ActivityInfo = autoclass('android.content.pm.ActivityInfo')
-
+Configuration = autoclass('android.content.res.Configuration')
+Surface = autoclass('android.view.Surface')
 
 class AndroidOrientation(Orientation):
 
@@ -38,6 +39,20 @@ class AndroidOrientation(Orientation):
             activity.setRequestedOrientation(
                 ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT)
 
-
+    def _get_orientation(self):
+        screenOrientation = activity.getResources().getConfiguration().orientation
+        surfaceRotation = activity.getWindowManager().getDefaultDisplay().getRotation()
+        
+        if surfaceRotation == Surface.ROTATION_0 or surfaceRotation == Surface.ROTATION_90:
+	        if screenOrientation == Configuration.ORIENTATION_PORTRAIT:
+		        return ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+	        elif screenOrientation == Configuration.ORIENTATION_LANDSCAPE:
+		        return ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        elif surfaceRotation == Surface.ROTATION_180 or surfaceRotation == Surface.ROTATION_270:
+	        if screenOrientation == Configuration.ORIENTATION_PORTRAIT:
+		        return ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT
+	        elif screenOrientation == Configuration.ORIENTATION_LANDSCAPE:
+		        return ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+		        
 def instance():
     return AndroidOrientation()


### PR DESCRIPTION
This addition come from this issue thread: [https://github.com/kivy/kivy/issues/4249](https://github.com/kivy/kivy/issues/4249).

It return both (normal and reverse) mode based on natural rotation of device. It should be portrait for smartphones and landscape for tablets.
I used the `ActivityInfo` orientation constants as output (for compatibility with others class methods) but i'm not sure if is the right way (i'm newbie with Android and java programming). 

I tested it on a smartphone with Android 4.4.  Should be tested on a tablet.

Review it.
Thank you guys!