### PR TITLE
add a generic kivy-based camera implementation for linux

### DIFF
--- a/examples/camera/main.py
+++ b/examples/camera/main.py
@@ -30,6 +30,7 @@ class CameraInterface(BoxLayout):
         self.ids.image.source = filename
         self.ids.image.reload()
 
+
 class CameraApp(App):
 
     def build(self):

--- a/examples/camera/main.py
+++ b/examples/camera/main.py
@@ -1,0 +1,40 @@
+import os.path
+from kivy.app import App
+from kivy.uix.boxlayout import BoxLayout
+from kivy.lang import Builder
+from plyer import camera
+
+Builder.load_string('''
+<CameraInterface>:
+    orientation: 'vertical'
+
+    Image:
+        id: image
+        source: None
+
+    Button:
+        text: "Take picture"
+        size_hint_y: None
+        height: "35sp"
+        on_press: root.take_picture()
+''')
+
+
+class CameraInterface(BoxLayout):
+
+    def take_picture(self):
+        filename = os.path.join(app.user_data_dir, 'tmp.jpg')
+        camera.take_picture(filename, self.on_picture)
+
+    def on_picture(self, filename):
+        self.ids.image.source = filename
+        self.ids.image.reload()
+
+class CameraApp(App):
+
+    def build(self):
+        return CameraInterface()
+
+if __name__ == "__main__":
+    app = CameraApp()
+    app.run()

--- a/plyer/platforms/linux/camera.py
+++ b/plyer/platforms/linux/camera.py
@@ -56,6 +56,7 @@ class GenericCameraWidget(BoxLayout):
         self.ids.camera._camera.release()
         app.root_window.remove_widget(self)
 
+
 class GenericCamera(Camera):
     widget = None
 
@@ -64,7 +65,6 @@ class GenericCamera(Camera):
         widget = GenericCameraWidget(callback=on_complete,
                                      filename=filename)
         app.root_window.add_widget(widget)
-
 
 
 def instance():

--- a/plyer/platforms/linux/camera.py
+++ b/plyer/platforms/linux/camera.py
@@ -1,0 +1,71 @@
+from os import unlink
+from kivy.app import App
+from kivy.properties import StringProperty, ObjectProperty
+from kivy.lang import Builder
+from kivy.uix.boxlayout import BoxLayout
+from plyer.facades import Camera
+
+Builder.load_string('''
+<GenericCameraWidget>:
+    orientation: 'vertical'
+    canvas:
+        Color:
+            rgb: 0, 0, 0
+        Rectangle:
+            pos: self.pos
+            size: self.size
+
+    Label:
+        text: "Plyer generic Camera"
+
+    Camera:
+        id: camera
+        resolution: (640, 480)
+        size_hint: 1, 1
+
+    BoxLayout:
+        Button:
+            text: "Shoot"
+            size_hint_y: None
+            height: "35sp"
+            on_press: root.shoot()
+        Button:
+            text: "Cancel"
+            size_hint_y: None
+            height: "35sp"
+            on_press: root.close()
+''')
+
+
+class GenericCameraWidget(BoxLayout):
+    filename = StringProperty()
+    callback = ObjectProperty()
+
+    def shoot(self):
+        self.ids.camera.texture.save(self.filename, flipped=False)
+        should_unlink = self.callback(self.filename)
+        if should_unlink:
+            try:
+                unlink(self.filename)
+            except:
+                pass
+        self.close()
+
+    def close(self):
+        app = App.get_running_app()
+        self.ids.camera._camera.release()
+        app.root_window.remove_widget(self)
+
+class GenericCamera(Camera):
+    widget = None
+
+    def _take_picture(self, on_complete, filename=None):
+        app = App.get_running_app()
+        widget = GenericCameraWidget(callback=on_complete,
+                                     filename=filename)
+        app.root_window.add_widget(widget)
+
+
+
+def instance():
+    return GenericCamera()


### PR DESCRIPTION
This PR depends on this kivy PR/feature request: https://github.com/kivy/kivy/pull/4430
Without the Kivy patch you can invoke the camera only once, because it is never freed and cannot be re-opened a second time