### PR TITLE
Fix TypeError if `LANG` is not set in on osx

### DIFF
--- a/plyer/platforms/macosx/uniqueid.py
+++ b/plyer/platforms/macosx/uniqueid.py
@@ -21,7 +21,6 @@ class OSXUniqueID(UniqueID):
         else:
             environ['LANG'] = old_lang
 
-
         if output:
             return output.split()[3][1:-1]
         else:

--- a/plyer/platforms/macosx/uniqueid.py
+++ b/plyer/platforms/macosx/uniqueid.py
@@ -16,7 +16,11 @@ class OSXUniqueID(UniqueID):
         ioreg_process.stdout.close()
         output = grep_process.communicate()[0]
 
-        environ['LANG'] = old_lang
+        if old_lang is None:
+            environ.pop('LANG')
+        else:
+            environ['LANG'] = old_lang
+
 
         if output:
             return output.split()[3][1:-1]


### PR DESCRIPTION
In macosx.uniqueid, `$LANG` is retrieved with `old_lang = environ.get('LANG')`. This means that if `LANG` is not set, `old_lang` will be none. When plyer later tries to restore the original value of lang, `putenv` will complain that we're not supplying a string.  I've corrected this by popping the inserted `LANG` value if `old_lang` is none.
