### PR TITLE
Decode bytes in filechooser to prevent TypeError

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -53,8 +53,14 @@ class SubprocessFileChooser(object):
             if ret is not None:
                 if ret == self.successretcode:
                     out = self._process.communicate()[0].strip()
-                    if isinstance(out, bytes):
-                        out = out.decode(encoding='utf_8', errors='strict')
+
+                    # Try to convert bytes to unicode
+                    try:
+                        if isinstance(out, bytes):
+                            out = out.decode(encoding='utf_8', errors='strict')
+                    except NameError:
+                        pass
+
                     self.selection = self._split_output(out)
                     return self.selection
                 else:

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -53,6 +53,8 @@ class SubprocessFileChooser(object):
             if ret is not None:
                 if ret == self.successretcode:
                     out = self._process.communicate()[0].strip()
+                    if isinstance(out, bytes):
+                        out = out.decode(encoding='utf_8', errors='strict')
                     self.selection = self._split_output(out)
                     return self.selection
                 else:


### PR DESCRIPTION
I got a TypeError on line 66 of the Linux filechooser.py file when trying to open a file on Ubuntu using Python 3.4 . The result of `self._process.communicate()[0].strip()` is being returned as bytes which causes the TypeError when calling `out.split`. This PR fixes the issue.