### PR TITLE
filechooser issues (windows)

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -44,14 +44,15 @@ class Win32FileChooser(object):
 
     def run(self):
         try:
+            self.selection = None
             if self.mode != "dir":
                 args = {}
 
                 if self.path:
                     args["InitialDir"] = os.path.dirname(self.path)
-                    path = os.path.splitext(os.path.dirname(self.path))
-                    args["File"] = path[0]
-                    args["DefExt"] = path[1]
+                    _, ext = os.path.splitext(self.path)
+                    args["File"] = self.path
+                    args["DefExt"] = ext
                 args["Title"] = self.title if self.title else "Pick a file..."
                 args["CustomFilter"] = 'Other file types\x00*.*\x00'
                 args["FilterIndex"] = 1
@@ -93,7 +94,8 @@ class Win32FileChooser(object):
                     self.title if self.title else "Pick a folder...",
                     0, None, None
                 )
-                self.selection = [str(shell.SHGetPathFromIDList(pidl))]
+                if pidl is not None:
+                    self.selection = [str(shell.SHGetPathFromIDList(pidl))]
 
             return self.selection
         except (RuntimeError, pywintypes.error):


### PR DESCRIPTION
- split extension as filter but keep filenname intact for filechooser open/save method (mode='open|save')

- prevent TypeError if no path get selected in choose_dir (mode='dir')