### PR TITLE
add bin and .buildozer directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ venv
 .project
 .pydevproject
 .settings/
+
+bin
+.buildozer


### PR DESCRIPTION
when we package our app using buildozer then bin and .buildozer directories are created which should not be committed.