### PR TITLE
Update android send SMS

### DIFF
--- a/examples/sms/buildozer.spec
+++ b/examples/sms/buildozer.spec
@@ -32,7 +32,7 @@ source.include_exts = py,png,jpg,kv,atlas
 version = 0.1
 
 # (list) Application requirements
-requirements = plyer,kivy
+requirements = plyer, kivy, hostpython2
 
 # (list) Garden requirements
 #garden_requirements =
@@ -64,7 +64,7 @@ android.permissions = SEND_SMS
 #android.minapi = 8
 
 # (int) Android SDK version to use
-#android.sdk = 21
+android.sdk = 24
 
 # (str) Android NDK version to use
 #android.ndk = 9c

--- a/examples/sms/main.py
+++ b/examples/sms/main.py
@@ -18,6 +18,7 @@ Builder.load_string('''
             id: recipient
             multiline: False
             on_text_validate: message.focus = True
+            input_filter: 'int'
     BoxLayout:
         Label:
             text: 'Message:'

--- a/plyer/platforms/android/sms.py
+++ b/plyer/platforms/android/sms.py
@@ -4,21 +4,29 @@ Android SMS
 '''
 
 from jnius import autoclass
+from jnius import cast
 from plyer.facades import Sms
 
-SmsManager = autoclass('android.telephony.SmsManager')
+PythonActivity = autoclass('org.renpy.android.PythonActivity')
+Intent = autoclass('android.content.Intent')
 
 
 class AndroidSms(Sms):
 
     def _send(self, **kwargs):
-        sms = SmsManager.getDefault()
-
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')
 
-        if sms:
-            sms.sendTextMessage(recipient, None, message, None, None)
+        sendIntent = Intent()
+        sendIntent.setAction(Intent.ACTION_VIEW)
+        sendIntent.setType('vnd.android-dir/mms-sms')
+        sendIntent.putExtra('address', recipient)
+        sendIntent.putExtra('sms_body', message)
+
+        currentActivity = cast(
+                                'android.app.Activity',
+                                PythonActivity.mActivity)
+        currentActivity.startActivity(sendIntent)
 
 
 def instance():

--- a/plyer/platforms/android/sms.py
+++ b/plyer/platforms/android/sms.py
@@ -7,7 +7,7 @@ from jnius import autoclass
 from jnius import cast
 from plyer.facades import Sms
 
-PythonActivity = autoclass('org.renpy.android.PythonActivity')
+PythonActivity = autoclass('org.kivy.android.PythonActivity')
 Intent = autoclass('android.content.Intent')
 
 


### PR DESCRIPTION
Not ready to merge
#261 
Current android sms feature in plyer uses sms manager api to send sms. I have tried to use intent which uses built-in sms app of device to send sms. But as soon as I press the send sms button, app stops responding. I tried many different ways but got no result.  
I request reviews from developers.
