### PR TITLE
Update readme and plyer/__init__.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Accelerometer                      X       X           X    X
 Call                               X       X
 Camera (taking picture)            X       X
 GPS                                X       X
+IR Blaster                         X
 Notifications                      X           X       X    X
 Text to speech                     X       X   X       X    X
 Email (open mail client)           X       X   X       X    X

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -5,7 +5,7 @@ Plyer
 '''
 
 __all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
-           'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
+           'email', 'filechooser', 'flash', 'gps', 'gyroscope', 'irblaster',
            'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator',
            'wifi')
 


### PR DESCRIPTION
`IR Blaster` is implemented for the android platform but was not mentioned in README.rst

`__all__` in `plyer/__init__.py` contains all the supported features but `flash` was missing from there though its `proxy` is created.

There were not any issues happening without these changes but the information should be updated.