### PR TITLE
Rename orientation to screenorientation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Unique ID                          X       X   X       X    X
 Gyroscope                          X       X
 Battery                            X       X   X       X    X
 Native file chooser                            X       X    X
-Orientation                        X
+Screen Orientation                 X
 Audio recording                    X
 Flash                              X       X
 Wifi                                           X       X    X

--- a/examples/screenorientation/buildozer.spec
+++ b/examples/screenorientation/buildozer.spec
@@ -1,10 +1,10 @@
 [app]
 
 # (str) Title of your application
-title = Plyer orientation test
+title = Plyer screen orientation test
 
 # (str) Package name
-package.name = plyerorientation
+package.name = plyerscreenorientation
 
 # (str) Package domain (needed for android/ios packaging)
 package.domain = org.test

--- a/examples/screenorientation/main.py
+++ b/examples/screenorientation/main.py
@@ -4,7 +4,7 @@ from kivy.base import runTouchApp
 from kivy.lang import Builder
 
 interface = Builder.load_string('''
-#:import orientation plyer.orientation
+#:import screenorientation plyer.screenorientation
 
 <WrapButton@Button>:
     text_size: self.size
@@ -18,26 +18,26 @@ BoxLayout:
         cols: 2
         WrapButton:
             text: 'portrait'
-            on_release: orientation.set_portrait()
+            on_release: screenorientation.set_portrait()
         WrapButton:
             text: 'portrait reverse'
-            on_release: orientation.set_portrait(reverse=True)
+            on_release: screenorientation.set_portrait(reverse=True)
         WrapButton:
             text: 'landscape'
-            on_release: orientation.set_landscape()
+            on_release: screenorientation.set_landscape()
         WrapButton:
             text: 'landscape reverse'
-            on_release: orientation.set_landscape(reverse=True)
+            on_release: screenorientation.set_landscape(reverse=True)
         WrapButton:
             text: 'free sensor'
-            on_release: orientation.set_sensor(mode='any')
+            on_release: screenorientation.set_sensor(mode='any')
         Widget:
         WrapButton:
             text: 'landscape sensor'
-            on_release: orientation.set_sensor(mode='landscape')
+            on_release: screenorientation.set_sensor(mode='landscape')
         WrapButton:
             text: 'portrait sensor'
-            on_release: orientation.set_sensor(mode='portrait')
+            on_release: screenorientation.set_sensor(mode='portrait')
 ''')
 
 runTouchApp(interface)

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -6,8 +6,8 @@ Plyer
 
 __all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
            'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
-           'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator',
-           'wifi')
+           'screenorientation', 'notification', 'sms', 'tts', 'uniqueid',
+           'vibrator', 'wifi')
 
 __version__ = '1.2.5dev'
 
@@ -48,8 +48,8 @@ gyroscope = Proxy('gyroscope', facades.Gyroscope)
 #: IrBlaster proxy to :class:`plyer.facades.IrBlaster`
 irblaster = Proxy('irblaster', facades.IrBlaster)
 
-#: Orientation proxy to :class:`plyer.facades.Orientation`
-orientation = Proxy('orientation', facades.Orientation)
+#: ScreenOrientation proxy to :class:`plyer.facades.ScreenOrientation`
+screenorientation = Proxy('screenorientation', facades.ScreenOrientation)
 
 #: Notification proxy to :class:`plyer.facades.Notification`
 notification = Proxy('notification', facades.Notification)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -8,8 +8,8 @@ Interface of all the features available.
 
 __all__ = ('Accelerometer', 'Audio', 'Battery', 'Call', 'Camera', 'Compass',
            'Email', 'FileChooser', 'GPS', 'Gyroscope', 'IrBlaster',
-           'Orientation', 'Notification', 'Sms', 'TTS', 'UniqueID', 'Vibrator',
-           'Wifi', 'Flash')
+           'ScreenOrientation', 'Notification', 'Sms', 'TTS', 'UniqueID',
+           'Vibrator', 'Wifi', 'Flash')
 
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
@@ -22,7 +22,7 @@ from plyer.facades.filechooser import FileChooser
 from plyer.facades.gps import GPS
 from plyer.facades.gyroscope import Gyroscope
 from plyer.facades.irblaster import IrBlaster
-from plyer.facades.orientation import Orientation
+from plyer.facades.screenorientation import ScreenOrientation
 from plyer.facades.notification import Notification
 from plyer.facades.sms import Sms
 from plyer.facades.tts import TTS

--- a/plyer/facades/screenorientation.py
+++ b/plyer/facades/screenorientation.py
@@ -1,9 +1,9 @@
 '''
-Orientation
+Screen Orientation
 ==========
 
-The :class:`Orientation` provides access to public methods to set orientation
-of your device.
+The :class:`ScreenOrientation` provides access to public methods to set
+screen orientation of your device.
 
 .. note::
     These settings are generally guidelines, the operating
@@ -17,23 +17,23 @@ Simple Examples
 
 To set landscape::
 
-    >>> from plyer import orientation
-    >>> orientation.set_landscape()
+    >>> from plyer import screenorientation
+    >>> screenorientation.set_landscape()
 
 To set portrait::
 
-    >>> orientation.set_portrait()
+    >>> screenorientation.set_portrait()
 
 To set sensor::
 
-    >>> orientation.set_sensor()
+    >>> screenorientation.set_sensor()
 
 '''
 
 
-class Orientation(object):
+class ScreenOrientation(object):
     '''
-    Orientation facade.
+    ScrrenOrientation facade.
     '''
 
     def set_landscape(self, reverse=False):

--- a/plyer/facades/screenorientation.py
+++ b/plyer/facades/screenorientation.py
@@ -33,7 +33,7 @@ To set sensor::
 
 class ScreenOrientation(object):
     '''
-    ScrrenOrientation facade.
+    ScreenOrientation facade.
     '''
 
     def set_landscape(self, reverse=False):

--- a/plyer/platforms/android/screenorientation.py
+++ b/plyer/platforms/android/screenorientation.py
@@ -1,11 +1,11 @@
 from jnius import autoclass, cast
 from plyer.platforms.android import activity
-from plyer.facades import Orientation
+from plyer.facades import ScreenOrientation
 
 ActivityInfo = autoclass('android.content.pm.ActivityInfo')
 
 
-class AndroidOrientation(Orientation):
+class AndroidScreenOrientation(ScreenOrientation):
 
     def _set_landscape(self, **kwargs):
         reverse = kwargs.get('reverse')
@@ -40,4 +40,4 @@ class AndroidOrientation(Orientation):
 
 
 def instance():
-    return AndroidOrientation()
+    return AndroidScreenOrientation()


### PR DESCRIPTION
There are two types of orientation features available in android, screen orientation and spatial orientation.
The one which is implemented is screen orientation and to prevent the ambiguity between the two, orientation is renamed to screen orientation.