### PR TITLE
Android Step Counter feature added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,8 @@ Native file chooser                            X       X    X
 Orientation                        X
 Audio recording                    X
 Flash                              X       X
-Wifi                                           X       X    X
+Wifi                                           X       X    X           
+Step Counter                       X
 ================================== ======= === ======= ==== =====
 
 Support

--- a/examples/stepcounter/buildozer.spec
+++ b/examples/stepcounter/buildozer.spec
@@ -1,0 +1,227 @@
+[app]
+
+# (str) Title of your application
+title = PlyerStepCounter
+
+# (str) Package name
+package.name = myapp
+
+# (str) Package domain (needed for android/ios packaging)
+package.domain = org.test
+
+# (str) Source code where the main.py live
+source.dir = .
+
+# (list) Source files to include (let empty to include all the files)
+source.include_exts = py,png,jpg,kv,atlas
+
+# (list) List of inclusions using pattern matching
+#source.include_patterns = assets/*,images/*.png
+
+# (list) Source files to exclude (let empty to not exclude anything)
+#source.exclude_exts = spec
+
+# (list) List of directory to exclude (let empty to not exclude anything)
+#source.exclude_dirs = tests, bin
+
+# (list) List of exclusions using pattern matching
+#source.exclude_patterns = license,images/*/*.jpg
+
+# (str) Application versioning (method 1)
+version = 0.1
+
+# (str) Application versioning (method 2)
+# version.regex = __version__ = ['"](.*)['"]
+# version.filename = %(source.dir)s/main.py
+
+# (list) Application requirements
+# comma seperated e.g. requirements = sqlite3,kivy
+requirements = kivy,plyer
+
+# (str) Custom source folders for requirements
+# Sets custom source for any requirements with recipes
+# requirements.source.kivy = ../../kivy
+
+# (list) Garden requirements
+#garden_requirements =
+
+# (str) Presplash of the application
+#presplash.filename = %(source.dir)s/data/presplash.png
+
+# (str) Icon of the application
+#icon.filename = %(source.dir)s/data/icon.png
+
+# (str) Supported orientation (one of landscape, portrait or all)
+orientation = portrait
+
+# (list) List of service to declare
+#services = NAME:ENTRYPOINT_TO_PY,NAME2:ENTRYPOINT2_TO_PY
+
+#
+# OSX Specific
+#
+
+#
+# author = © Copyright Info
+
+#
+# Android specific
+#
+
+# (bool) Indicate if the application should be fullscreen or not
+fullscreen = 0
+
+# (list) Permissions
+#android.permissions = INTERNET
+
+# (int) Android API to use
+#android.api = 19
+
+# (int) Minimum API required
+#android.minapi = 9
+
+# (int) Android SDK version to use
+#android.sdk = 20
+
+# (str) Android NDK version to use
+#android.ndk = 9c
+
+# (bool) Use --private data storage (True) or --dir public storage (False)
+#android.private_storage = True
+
+# (str) Android NDK directory (if empty, it will be automatically downloaded.)
+#android.ndk_path =
+
+# (str) Android SDK directory (if empty, it will be automatically downloaded.)
+#android.sdk_path =
+
+# (str) ANT directory (if empty, it will be automatically downloaded.)
+#android.ant_path =
+
+# (str) python-for-android git clone directory (if empty, it will be automatically cloned from github)
+#android.p4a_dir =
+
+# (list) python-for-android whitelist
+#android.p4a_whitelist =
+
+# (bool) If True, then skip trying to update the Android sdk
+# This can be useful to avoid excess Internet downloads or save time
+# when an update is due and you just want to test/build your package
+# android.skip_update = False
+
+# (str) Android entry point, default is ok for Kivy-based app
+#android.entrypoint = org.renpy.android.PythonActivity
+
+# (list) List of Java .jar files to add to the libs so that pyjnius can access
+# their classes. Don't add jars that you do not need, since extra jars can slow
+# down the build process. Allows wildcards matching, for example:
+# OUYA-ODK/libs/*.jar
+#android.add_jars = foo.jar,bar.jar,path/to/more/*.jar
+
+# (list) List of Java files to add to the android project (can be java or a
+# directory containing the files)
+#android.add_src =
+
+# (str) python-for-android branch to use, if not master, useful to try
+# not yet merged features.
+#android.branch = master
+
+# (str) OUYA Console category. Should be one of GAME or APP
+# If you leave this blank, OUYA support will not be enabled
+#android.ouya.category = GAME
+
+# (str) Filename of OUYA Console icon. It must be a 732x412 png image.
+#android.ouya.icon.filename = %(source.dir)s/data/ouya_icon.png
+
+# (str) XML file to include as an intent filters in <activity> tag
+#android.manifest.intent_filters =
+
+# (list) Android additionnal libraries to copy into libs/armeabi
+#android.add_libs_armeabi = libs/android/*.so
+#android.add_libs_armeabi_v7a = libs/android-v7/*.so
+#android.add_libs_x86 = libs/android-x86/*.so
+#android.add_libs_mips = libs/android-mips/*.so
+
+# (bool) Indicate whether the screen should stay on
+# Don't forget to add the WAKE_LOCK permission if you set this to True
+#android.wakelock = False
+
+# (list) Android application meta-data to set (key=value format)
+#android.meta_data =
+
+# (list) Android library project to add (will be added in the
+# project.properties automatically.)
+#android.library_references =
+
+# (str) Android logcat filters to use
+#android.logcat_filters = *:S python:D
+
+# (bool) Copy library instead of making a libpymodules.so
+#android.copy_libs = 1
+
+#
+# iOS specific
+#
+
+# (str) Path to a custom kivy-ios folder
+#ios.kivy_ios_dir = ../kivy-ios
+
+# (str) Name of the certificate to use for signing the debug version
+# Get a list of available identities: buildozer ios list_identities
+#ios.codesign.debug = "iPhone Developer: <lastname> <firstname> (<hexstring>)"
+
+# (str) Name of the certificate to use for signing the release version
+#ios.codesign.release = %(ios.codesign.debug)s
+
+
+[buildozer]
+
+# (int) Log level (0 = error only, 1 = info, 2 = debug (with command output))
+log_level = 2
+
+# (int) Display warning if buildozer is run as root (0 = False, 1 = True)
+warn_on_root = 1
+
+# (str) Path to build artifact storage, absolute or relative to spec file
+# build_dir = ./.buildozer
+
+# (str) Path to build output (i.e. .apk, .ipa) storage
+# bin_dir = ./bin
+
+#    -----------------------------------------------------------------------------
+#    List as sections
+#
+#    You can define all the "list" as [section:key].
+#    Each line will be considered as a option to the list.
+#    Let's take [app] / source.exclude_patterns.
+#    Instead of doing:
+#
+#[app]
+#source.exclude_patterns = license,data/audio/*.wav,data/images/original/*
+#
+#    This can be translated into:
+#
+#[app:source.exclude_patterns]
+#license
+#data/audio/*.wav
+#data/images/original/*
+#
+
+
+#    -----------------------------------------------------------------------------
+#    Profiles
+#
+#    You can extend section / key with a profile
+#    For example, you want to deploy a demo version of your application without
+#    HD content. You could first change the title to add "(demo)" in the name
+#    and extend the excluded directories to remove the HD content.
+#
+#[app@demo]
+#title = My Application (demo)
+#
+#[app:source.exclude_patterns@demo]
+#images/hd/*
+#
+#    Then, invoke the command line with the "demo" profile:
+#
+#buildozer --profile demo android debug

--- a/examples/stepcounter/main.py
+++ b/examples/stepcounter/main.py
@@ -1,0 +1,68 @@
+from kivy.app import App
+from kivy.clock import Clock
+from kivy.lang import Builder
+from kivy.properties import NumericProperty
+from kivy.properties import ObjectProperty
+from kivy.uix.boxlayout import BoxLayout
+
+
+Builder.load_string('''
+#:import facade plyer.stepcounter
+<StepCounterInterface>:
+    facade: facade
+    orientation: 'vertical'
+    padding: '50dp'
+    spacing: '20dp'
+    BoxLayout:
+        orientation: 'horizontal'
+        size_hint_y: 0.3
+        Button:
+            id: button_enable
+            text: 'Enable'
+            disabled: False
+            on_release:
+                root.enable()
+                button_disable.disabled = not button_disable.disabled
+                button_enable.disabled = not button_enable.disabled
+        Button:
+            id: button_disable
+            text: 'Disable'
+            disabled: True
+            on_release:
+                root.disable()
+                button_disable.disabled = not button_disable.disabled
+                button_enable.disabled = not button_enable.disabled
+    Label:
+        text: 'Steps: ' + str(root.steps)
+        
+''')
+
+
+class StepCounterInterface(BoxLayout):
+    '''Root Widget.'''
+    steps = NumericProperty(0)
+    facade = ObjectProperty()
+
+    def enable(self):
+        self.facade.enable()
+        Clock.schedule_interval(self.get_count, 1 / 20.)
+
+    def disable(self):
+        self.facade.disable()
+        Clock.unschedule(self.get_count)
+
+    def get_count(self, dt):
+        if self.facade.count != None:
+        self.steps = self.facade.count
+
+
+class StepCounterApp(App):
+
+    def build(self):
+        return StepCounterInterface()
+
+    def on_pause(self):
+        return True
+
+if __name__ == "__main__":
+    StepCounterApp().run()

--- a/examples/stepcounter/main.py
+++ b/examples/stepcounter/main.py
@@ -34,7 +34,6 @@ Builder.load_string('''
                 button_enable.disabled = not button_enable.disabled
     Label:
         text: 'Steps: ' + str(root.steps)
-        
 ''')
 
 
@@ -52,8 +51,8 @@ class StepCounterInterface(BoxLayout):
         Clock.unschedule(self.get_count)
 
     def get_count(self, dt):
-        if self.facade.count != None:
-        self.steps = self.facade.count
+        if self.facade.count is not None:
+            self.steps = self.facade.count
 
 
 class StepCounterApp(App):

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -7,7 +7,7 @@ Plyer
 __all__ = ('accelerometer', 'audio', 'battery', 'call', 'camera', 'compass',
            'email', 'filechooser', 'gps', 'gyroscope', 'irblaster',
            'orientation', 'notification', 'sms', 'tts', 'uniqueid', 'vibrator',
-           'wifi')
+           'wifi', 'stepcounter')
 
 __version__ = '1.2.5dev'
 
@@ -71,3 +71,6 @@ flash = Proxy('flash', facades.Flash)
 
 #: Wifi proxy to :class:`plyer.facades.Wifi`
 wifi = Proxy('wifi', facades.Wifi)
+
+#: StepCounter proxy to :class:`plyer.facades.StepCounter`
+stepcounter = Proxy('stepcounter', facades.StepCounter)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -9,7 +9,7 @@ Interface of all the features available.
 __all__ = ('Accelerometer', 'Audio', 'Battery', 'Call', 'Camera', 'Compass',
            'Email', 'FileChooser', 'GPS', 'Gyroscope', 'IrBlaster',
            'Orientation', 'Notification', 'Sms', 'TTS', 'UniqueID', 'Vibrator',
-           'Wifi', 'Flash')
+           'Wifi', 'Flash', 'StepCounter')
 
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
@@ -30,3 +30,4 @@ from plyer.facades.uniqueid import UniqueID
 from plyer.facades.vibrator import Vibrator
 from plyer.facades.flash import Flash
 from plyer.facades.wifi import Wifi
+from plyer.facades.stepcounter import StepCounter

--- a/plyer/facades/stepcounter.py
+++ b/plyer/facades/stepcounter.py
@@ -1,0 +1,40 @@
+class StepCounter(object):
+    '''Step Counter facade.
+    Step Counter sensor returns the number of steps taken by
+    the user since the last reboot while activated.
+
+    If you want to continuously track the number of steps over a
+    long period of time, do NOT unregister for this sensor,
+    so that it keeps counting steps in the background even when
+    the AP is in suspend mode and report the aggregate count when the AP is awake. 
+
+    With method `enable` you can turn on Rotation Vector sensor and 'disable'
+    method stops the sensor.
+    Use property `vector` to get rotation vector values.
+    '''
+
+    @property
+    def count(self):
+        '''Current number of steps taken by the user
+        since the last reboot while activated
+        '''
+        return self._get_count()
+
+    def enable(self):
+        '''Enable Step Counter sensor.'''
+        self._enable()
+
+    def disable(self):
+        '''Disable Step Counter sensor.'''
+        self._disable()
+
+    #private
+        
+    def _get_count(self, **kwargs):
+        raise NotImplementedError()
+
+    def _enable(self, **kwargs):
+        raise NotImplementedError()
+
+    def _disable(self, **kwargs):
+        raise NotImplementedError()

--- a/plyer/facades/stepcounter.py
+++ b/plyer/facades/stepcounter.py
@@ -2,12 +2,11 @@ class StepCounter(object):
     '''Step Counter facade.
     Step Counter sensor returns the number of steps taken by
     the user since the last reboot while activated.
-
     If you want to continuously track the number of steps over a
     long period of time, do NOT unregister for this sensor,
     so that it keeps counting steps in the background even when
-    the AP is in suspend mode and report the aggregate count when the AP is awake. 
-
+    the AP is in suspend mode and report the aggregate count
+    when the AP is awake.
     With method `enable` you can turn on Rotation Vector sensor and 'disable'
     method stops the sensor.
     Use property `vector` to get rotation vector values.
@@ -29,7 +28,6 @@ class StepCounter(object):
         self._disable()
 
     #private
-        
     def _get_count(self, **kwargs):
         raise NotImplementedError()
 

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -82,7 +82,7 @@ class Wifi(object):
         '''
         Return a dictionary of secified network.
         '''
-        return self._get_network_info(name=name)
+        return self._get_access_points(name=name)
 
     def get_available_wifi(self):
         '''

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -82,7 +82,7 @@ class Wifi(object):
         '''
         Return a dictionary of secified network.
         '''
-        return self._get_access_points(name=name)
+        return self._get_network_info(name=name)
 
     def get_available_wifi(self):
         '''

--- a/plyer/platforms/android/stepcounter.py
+++ b/plyer/platforms/android/stepcounter.py
@@ -1,0 +1,64 @@
+from jnius import autoclass
+from jnius import cast
+from jnius import java_method
+from jnius import PythonJavaClass
+
+from plyer.facades import StepCounter
+from plyer.platforms.android import activity
+
+ActivityInfo = autoclass('android.content.pm.ActivityInfo')
+Context = autoclass('android.content.Context')
+Sensor = autoclass('android.hardware.Sensor')
+SensorManager = autoclass('android.hardware.SensorManager')
+
+
+class StepCounterSensorListener(PythonJavaClass):
+    __javainterfaces__ = ['android/hardware/SensorEventListener']
+
+    def __init__(self):
+        super(StepCounterSensorListener, self).__init__()
+        service = activity.getSystemService(Context.SENSOR_SERVICE)
+        self.SensorManager = cast('android.hardware.SensorManager', service)
+
+        self.sensor = self.SensorManager.getDefaultSensor(
+            Sensor.TYPE_STEP_COUNTER)
+        self.value = None
+
+    def enable(self):
+        self.SensorManager.registerListener(self, self.sensor,
+                    SensorManager.SENSOR_DELAY_NORMAL)
+
+    def disable(self):
+        self.SensorManager.unregisterListener(self, self.sensor)
+
+    @java_method('(Landroid/hardware/SensorEvent;)V')
+    def onSensorChanged(self, event):
+        self.value = event.values[0]
+
+    @java_method('(Landroid/hardware/Sensor;I)V')
+    def onAccuracyChanged(self, sensor, accuracy):
+        pass
+
+
+class AndroidStepCounter(StepCounter):
+
+    listener = None
+
+    def _get_count(self):
+        if self.listener and self.listener.value:
+            count = self.listener.value
+            return count
+
+    def _enable(self):
+        if not self.listener:
+            self.listener = StepCounterSensorListener()
+            self.listener.enable()
+
+    def _disable(self):
+        if self.listener:
+            self.listener.disable()
+            delattr(self, 'listener')
+
+
+def instance():
+    return AndroidStepCounter()


### PR DESCRIPTION
Step Counter sensor returns the number of steps taken by the user since the last reboot while activated. The value is returned as a float (with the fractional part set to zero) and is reset to zero only on a system reboot. 

If someone wants to continuously track the number of steps over a long period of time, do NOT unregister for this sensor, so that it keeps counting steps in the background even when the AP is in suspend mode and report the aggregate count when the AP is awake. Application needs to stay registered for this sensor because step counter does not count steps if it is not activated