### PR TITLE
Bugfix: set encoding for Python 2 compile

### DIFF
--- a/plyer/facades/temperature.py
+++ b/plyer/facades/temperature.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 class Temperature(object):
     '''Temperature facade.
 

--- a/plyer/facades/temperature.py
+++ b/plyer/facades/temperature.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
 class Temperature(object):
     '''Temperature facade.
 


### PR DESCRIPTION
This file now has some UTF8 encoded docstrings, so it needs to set the charset.
See https://github.com/kivy/plyer/issues/312