### PR TITLE
Pep8 fix in temperature.py

### DIFF
--- a/plyer/facades/temperature.py
+++ b/plyer/facades/temperature.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+
 class Temperature(object):
     '''Temperature facade.
 

--- a/plyer/facades/temperature.py
+++ b/plyer/facades/temperature.py
@@ -26,7 +26,7 @@ class Temperature(object):
         '''Disable temperature sensor.'''
         self._disable()
 
-    #private
+    # private
 
     def _get_temperature(self, **kwargs):
         raise NotImplementedError()


### PR DESCRIPTION
fixes pep8 error in temperature facade. Should be merged because the error prevents plyer to install in system.