### PR TITLE
Update win_api_defs.py

### DIFF
--- a/plyer/platforms/win/libs/win_api_defs.py
+++ b/plyer/platforms/win/libs/win_api_defs.py
@@ -183,7 +183,7 @@ LoadIconW.argtypes = [HINSTANCE, LPCWSTR]
 LoadIconW.restype = HICON
 
 
-class SYSTEM_POWER_STATUS(ctypes.Structure):
+class SYSTEM_POWER_STATUS(Structure):
     _fields_ = [
         ('ACLineStatus', BYTE),
         ('BatteryFlag', BYTE),
@@ -193,8 +193,8 @@ class SYSTEM_POWER_STATUS(ctypes.Structure):
         ('BatteryFullLifeTime', DWORD),
     ]
 
-SystemPowerStatusP = ctypes.POINTER(SYSTEM_POWER_STATUS)
+SystemPowerStatusP = POINTER(SYSTEM_POWER_STATUS)
 
-GetSystemPowerStatus = ctypes.windll.kernel32.GetSystemPowerStatus
+GetSystemPowerStatus = windll.kernel32.GetSystemPowerStatus
 GetSystemPowerStatus.argtypes = [SystemPowerStatusP]
 GetSystemPowerStatus.restype = BOOL


### PR DESCRIPTION
No use of having `ctypes.` in  `ctypes.Structure` or `ctypes.POINTER` or `ctypes.windll` when the corresponding libraries are already imported above.