### PR TITLE
Warn instead stder.write for linux notif errors

### DIFF
--- a/plyer/platforms/linux/notification.py
+++ b/plyer/platforms/linux/notification.py
@@ -1,3 +1,4 @@
+import warnings
 import subprocess
 from plyer.facades import Notification
 from plyer.utils import whereis_exe
@@ -47,9 +48,9 @@ def instance():
         import dbus
         return NotifyDbus()
     except ImportError:
-        sys.stderr.write("python-dbus not installed. try:"
-                         "`sudo pip install python-dbus`.")
+        msg = "python-dbus not installed. try: `sudo pip install python-dbus`."
+        warnings.warn(msg)
     if whereis_exe('notify-send'):
         return NotifySendNotification()
-    sys.stderr.write("notify-send not found.")
+    warnings.warn("notify-send not found.")
     return Notification()


### PR DESCRIPTION
It does the same thing, except you can silence it if you wish. Given that you may very well not want to ever use the db-bus binding, it's nice to have the choice of sticking to notify-send without any mention of it in stder if you feel like it.