### PR TITLE
Switch to unicode in macosx battery.py

### DIFF
--- a/plyer/platforms/macosx/battery.py
+++ b/plyer/platforms/macosx/battery.py
@@ -31,16 +31,16 @@ class OSXBattery(Battery):
             return status
 
         is_charging = max_capacity = current_capacity = None
-        for line in output.splitlines():
-            if b'IsCharging' in line:
-                is_charging = line.rpartition(b'=')[-1].strip()
-            if b'MaxCapacity' in line:
-                max_capacity = float(line.rpartition(b'=')[-1].strip())
-            if b'CurrentCapacity' in line:
-                current_capacity = float(line.rpartition(b'=')[-1].strip())
+        for line in output.decode('utf-8').splitlines():
+            if 'IsCharging' in line:
+                is_charging = line.rpartition('=')[-1].strip()
+            if 'MaxCapacity' in line:
+                max_capacity = float(line.rpartition('=')[-1].strip())
+            if 'CurrentCapacity' in line:
+                current_capacity = float(line.rpartition('=')[-1].strip())
 
         if is_charging:
-            status['isCharging'] = is_charging == b"Yes"
+            status['isCharging'] = is_charging == "Yes"
 
         if current_capacity and max_capacity:
             status['percentage'] = 100.0 * current_capacity / max_capacity


### PR DESCRIPTION
Switching to unicode as described in https://github.com/kivy/plyer/commit/3892b41a8d9a8006754d95c4dfc2903f12d16bf0#r29926437.