### PR TITLE
Add script for CI deployment to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,11 @@ script:
                       --env COVERALLS_SERVICE_NAME=travis-ci
                       --env TRAVIS_JOB_ID=$TRAVIS_JOB_ID
                       --env TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+                      --env PLYER_DEPLOY=${PLYER_DEPLOY:-"0"}
+                      --env TWINE_REPOSITORY=$TWINE_REPOSITORY
+                      --env TWINE_REPOSITORY_URL=$TWINE_REPOSITORY_URL
+                      --env TWINE_USERNAME=$TWINE_USERNAME
+                      --env TWINE_PASSWORD=$TWINE_PASSWORD
                       plyer:py3;
 
               else

--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -5,3 +5,4 @@ pylint
 coverage
 coveralls
 cython
+twine

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,3 +34,9 @@ nosetests \
 # submit coverage report from (nose) tests to coveralls.io
 # requires: REPO_TOKEN, SERVICE_NAME, JOB_ID, PULL_REQUEST
 coveralls || true
+
+# deploy to PyPI if set in CI with PLYER_DEPLOY variable
+if [ "$PLYER_DEPLOY" = "1" ]; then
+    $PYTHON setup.py sdist bdist_wheel
+    $PYTHON -m twine upload dist/*
+fi


### PR DESCRIPTION
Since plyer is source dist only, these lines are enough to upload it. For binary dist it'd be a little longer. Add deploy variable with `1` value in CI settings to run also the deploy in the docker py3 job (defaults to `0` in the script, so no need for the variable in the settings), then run the build. Using `kivybot` PyPI account linked to the bot email account. Password is encrypted in the settings.

Currently the server is for testing packages, I'll switch once the first build passes.