### PR TITLE
Fix style issues in utils, compat and setup.py

### DIFF
--- a/plyer/compat.py
+++ b/plyer/compat.py
@@ -2,6 +2,7 @@
 Compatibility module for Python 2.7 and > 3.3
 =============================================
 '''
+# pylint: disable=invalid-name
 
 __all__ = ('PY2', 'string_types', 'queue', 'iterkeys',
            'itervalues', 'iteritems', 'xrange')
@@ -19,6 +20,8 @@ PY2 = sys.version_info[0] == 2
 string_types = None
 text_type = None
 if PY2:
+    # pylint: disable=undefined-variable
+    # built-in actually, so it is defined in globals() for py2
     string_types = basestring
     text_type = unicode
 else:
@@ -34,6 +37,8 @@ else:
     iteritems = lambda d: iter(d.items())
 
 if PY2:
+    # pylint: disable=undefined-variable
+    # built-in actually, so it is defined in globals() for py2
     xrange = xrange
 else:
     xrange = range

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,16 @@
 #!/usr/bin/env python
+'''
+Setup.py
+========
+
+For MacOS or iOS install additional dependency PyOBJus::
+
+    pip install https://github.com/kivy/pyobjus/zipball/master
+
+For Android install additional dependency PyJNIus::
+
+    pip install https://github.com/kivy/pyjnius/zipball/master
+'''
 
 from os.path import dirname, join
 import plyer
@@ -8,8 +20,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-curdir = dirname(__file__)
-packages = [
+CURDIR = dirname(__file__)
+PACKAGES = [
     'plyer',
     'plyer.facades',
     'plyer.platforms',
@@ -22,24 +34,24 @@ packages = [
     'plyer.platforms.macosx.libs',
 ]
 
-with open(join(curdir, "README.rst")) as fd:
-    readme = fd.read()
-with open(join(curdir, "CHANGELOG.md")) as fd:
-    changelog = fd.read()
+with open(join(CURDIR, "README.rst")) as fd:
+    README = fd.read()
+with open(join(CURDIR, "CHANGELOG.md")) as fd:
+    CHANGELOG = fd.read()
 
 setup(
     name='plyer',
     version=plyer.__version__,
     description='Platform-independent wrapper for platform-dependent APIs',
-    long_description=readme + "\n\n" + changelog,
+    long_description=README + "\n\n" + CHANGELOG,
     author='Kivy team',
     author_email='mat@kivy.org',
     url='https://plyer.readthedocs.org/en/latest/',
-    packages=packages,
+    packages=PACKAGES,
     package_data={'': ['LICENSE', 'README.rst']},
     package_dir={'plyer': 'plyer'},
     include_package_data=True,
-    license=open(join(curdir, 'LICENSE')).read(),
+    license=open(join(CURDIR, 'LICENSE')).read(),
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Some errors are ignored due to py2/py3 compat and basically everything depending on some specific name + it makes no sense to make e.g. `XRANGE` (all upcase) for built-ins.

Also, I added the original author of `Proxy()` and its license (it's PSF, but just to be safe) to the docstring.