### PR TITLE
Fix Travis build for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,10 @@ before_install:
           rvm get head;
       fi;
 
-    # use real branch name instead of detached HEAD
-    - git checkout ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-
+    # use real branch name instead of detached HEAD unless PR
+    - if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then
+          git checkout $TRAVIS_BRANCH;
+      fi;
 
 install:
     # build docker images


### PR DESCRIPTION
Use the original `git checkout -qf FETCH_HEAD` from travis because pull requests are located in "refs/pulls/123/merge" which we won't get via Travis env vars.