### PR TITLE
Remove notification webhook from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,11 +161,3 @@ script:
               --nocapture
               ./plyer/tests;
       fi;
-
-notifications:
-    webhooks:
-        urls:
-            - https://kivy.org:5000/travisevent
-        on_success: always
-        on_failure: always
-        on_start: always


### PR DESCRIPTION
The IRC webhook has been broken in the past year, and we also moved to Discord.