### PR TITLE
Add extra options for installation via setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,21 @@ For Android install additional dependency PyJNIus::
 from os.path import dirname, join
 import plyer
 
+EXTRA_OPTIONS = {}
+
 try:
     from setuptools import setup
+    EXTRA_OPTIONS = dict(
+        EXTRA_OPTIONS, **{
+            'extras_require': {
+                'ios': ['pyobjus'],
+                'macosx': ['pyobjus'],
+                'android': ['pyjnius'],
+                'dev': ['mock', 'pycodestyle', 'pylint']
+            }
+        }
+    )
+
 except ImportError:
     from distutils.core import setup
 
@@ -66,4 +79,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
+    **EXTRA_OPTIONS
 )


### PR DESCRIPTION
More comfortable than using `try`/`except` and shut the user down with a warning. Instead we should provide an interface to install the conditional requirement, i.e. in this case `pyjnius` for Android platform and `pyobjus` for macOS/iOS.

Choosing non-intrusive installation option because it might break stuff for mobile platforms if enforcing the requirements on pyobjus/pyjnius + there are no releases of pyobjus/pyjnius yet (wip), therefore:

    pip install plyer[macosx]

will for now just crash. The `dev` option will work though.