### PR TITLE
Add missing parameter for Windows' WlanCloseHandle()

### DIFF
--- a/plyer/platforms/win/libs/wifi_defs.py
+++ b/plyer/platforms/win/libs/wifi_defs.py
@@ -331,7 +331,7 @@ def _connect(network, parameters):
                            None)
         if wlan:
             sys_exit(FormatError(wlan))
-        WlanCloseHandle(ClientHandle)
+        WlanCloseHandle(ClientHandle, None)
     finally:
         WlanFreeMemory(pInterfaceList)
 
@@ -374,7 +374,7 @@ def _disconnect():
             )
             if wlan:
                 sys_exit(FormatError(wlan))
-            WlanCloseHandle(ClientHandle)
+            WlanCloseHandle(ClientHandle, None)
 
     finally:
         WlanFreeMemory(pInterfaceList)
@@ -449,7 +449,7 @@ def _start_scanning():
 
                 if wlan:
                     sys_exit(FormatError(wlan))
-                WlanCloseHandle(ClientHandle)
+                WlanCloseHandle(ClientHandle, None)
 
             finally:
                 WlanFreeMemory(pAvailableNetworkList)


### PR DESCRIPTION
According to Microsoft's documentation `WlanCloseHandle()` requires *two* parameters and the second one is reserved, so we can put `None` in there.

ref: https://docs.microsoft.com/en-us/windows/desktop/api/wlanapi/nf-wlanapi-wlanclosehandle