### PR TITLE
Fix b' embedded in the path string for Windows' choose_dir()

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -96,7 +96,7 @@ class Win32FileChooser(object):
                     self.title if self.title else "Pick a folder...",
                     0, None, None
                 )
-                self.selection = [str(get_path(pidl))]
+                self.selection = [str(get_path(pidl).decode('utf-8'))]
 
             return self.selection
         except (RuntimeError, pywintypes.error):


### PR DESCRIPTION
Fixes `"b'C:\\whatever'"` path, but doesn't break it with converting it to unicode, since the rest of the methods still use bytes on Py2 and unicode on Py3.