### PR TITLE
Fix not decoding bytes in Linux orientation.py

### DIFF
--- a/plyer/platforms/linux/orientation.py
+++ b/plyer/platforms/linux/orientation.py
@@ -6,16 +6,20 @@ class LinuxOrientation(Orientation):
 
     def _set_landscape(self, **kwargs):
         self.rotate = 'normal'
-        self.screen = sb.check_output("xrandr -q | grep ' connected' \
-                              |  head -n 1 | cut -d ' ' -f1", shell=True)
-        self.screen = self.screen.split('\n')[0]
+        self.screen = sb.check_output(
+            "xrandr -q | grep ' connected' |  head -n 1 | cut -d ' ' -f1",
+            shell=True
+        )
+        self.screen = self.screen.decode('utf-8').split('\n')[0]
         sb.call(["xrandr", "--output", self.screen, "--rotate", self.rotate])
 
     def _set_portrait(self, **kwargs):
         self.rotate = 'left'
-        self.screen = sb.check_output("xrandr -q | grep ' connected' \
-                              |  head -n 1 | cut -d ' ' -f1", shell=True)
-        self.screen = self.screen.split('\n')[0]
+        self.screen = sb.check_output(
+            "xrandr -q | grep ' connected' |  head -n 1 | cut -d ' ' -f1",
+            shell=True
+        )
+        self.screen = self.screen.decode('utf-8').split('\n')[0]
         sb.call(["xrandr", "--output", self.screen, "--rotate", self.rotate])
 
 


### PR DESCRIPTION
Otherwise it fails on Py3 with expecting bytes in `split()`.