### PR TITLE
Cron deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,7 @@ script:
                       --tty
                       --env COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN
                       --env COVERALLS_SERVICE_NAME=travis-ci
+                      --env TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
                       --env TRAVIS_JOB_ID=$TRAVIS_JOB_ID
                       --env TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
                       --env PLYER_DEPLOY=${PLYER_DEPLOY:-"0"}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,10 @@ nosetests \
 coveralls || true
 
 # deploy to PyPI if set in CI with PLYER_DEPLOY variable
-if [ "$PLYER_DEPLOY" = "1" ]; then
+if [ "$PLYER_DEPLOY" = "1" ] || [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+        $PYTHON plyer_deploy.py
+    fi
     $PYTHON setup.py sdist bdist_wheel
     $PYTHON -m twine upload dist/*
 fi

--- a/plyer_deploy.py
+++ b/plyer_deploy.py
@@ -1,0 +1,70 @@
+'''
+Add a build section to the plyer.__version__ with standard .dev0 string.
+Versions are fetched from PyPI according to the current version of plyer.
+
+If there has been a release e.g. 1.2.3 and we bump the version on master
+to 1.2.4.dev0, this fetches all versions that start with 1.2.4 i.e. right
+after the release none and via cronjob there will be a 1.2.4.0.dev0 release.
+Afterwards 1.2.4.1.dev0, etc until we bump to e.g. 1.2.5.dev0.
+'''
+
+import ssl
+import json
+from os.path import join
+from urllib.request import urlopen
+import plyer
+
+# pylint: disable=protected-access
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def get_build_section():
+    '''
+    Get all versions from PyPI that start with X.Y.Z of the current version.
+    '''
+
+    response = urlopen("https://pypi.org/pypi/plyer/json")
+    versions = list(json.loads(response.read())["releases"].keys())
+    print("Found these versions on PyPI: '{}'".format(versions))
+
+    # ordinary release starts with X.Y.Z
+    # scheduled increment adds the fourth section
+    current = len([v for v in versions if v.startswith(plyer.__version__)])
+    return current
+
+
+def replace_version():
+    '''
+    Replace current version with X.Y.Z.b.dev0, where b is a build number.
+    '''
+
+    with open(join('plyer', '__init__.py')) as init:
+        lines = init.readlines()
+
+    build = get_build_section()
+    print("New build section number is '{}'".format(build))
+
+    # get original version
+    curv = plyer.__version__.split('.')
+
+    # assemble new one without "dev"/"dev0" thingy
+    new = '.'.join(
+        curv[:2] + [
+            curv[2].strip('.dev0').strip('.dev').strip('dev0').strip('dev')
+        ]
+    )
+
+    # create standardized new version
+    new = '.'.join([new, str(build), 'dev0'])
+    print("New build version is '{}'".format(new))
+
+    with open(join('plyer', '__init__.py'), 'w') as init:
+        for line in lines:
+            if not line.startswith('__version__'):
+                init.write(line)
+                continue
+            init.write("__version__ = '{}'".format(new))
+
+
+if __name__ == '__main__':
+    replace_version()


### PR DESCRIPTION
Add a build section to the `plyer.__version__` with standard .dev0 string. Versions are fetched from PyPI according to the current version of plyer. If there has been a release e.g. 1.2.3 and we bump the version on master to 1.2.4.dev0, this fetches all versions that start with 1.2.4 i.e. right after the release there are none and via cronjob there will be a 1.2.4.0.dev0 release. Afterwards 1.2.4.1.dev0, 1.2.4.2.dev0, etc until we bump to e.g. 1.2.5.dev0.

Event type according to https://docs.travis-ci.com/user/environment-variables/.

Current setup on Travis (does nothing serious until this is merged):

![image](https://user-images.githubusercontent.com/8825439/46920855-9eeb7100-cff4-11e8-9e3e-42dda49ffc94.png)
