### PR TITLE
Rebased PR #239 + fixes

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -26,10 +26,6 @@ class Win32FileChooser(object):
     by Windows itself):
     * preview
     * window-icon
-    * multiple
-    * show_hidden
-    * filters
-    * path
 
     Known issues:
     * non-existins folders such as: Network, Control Panel, My Computer, Trash,
@@ -66,6 +62,7 @@ class Win32FileChooser(object):
                 args["CustomFilter"] = 'Other file types\x00*.*\x00'
                 args["FilterIndex"] = 1
 
+                # e.g. open_file(filters=['*.txt', '*.py'])
                 filters = ""
                 for f in self.filters:
                     if type(f) == str:
@@ -78,7 +75,8 @@ class Win32FileChooser(object):
                 flags |= win32con.OFN_OVERWRITEPROMPT
 
                 if self.multiple:
-                    flags |= win32con.OFN_ALLOWmultiple | win32con.OFN_EXPLORER
+                    flags |= win32con.OFN_ALLOWMULTISELECT
+                    flags |= win32con.OFN_EXPLORER
                 if self.show_hidden:
                     flags |= win32con.OFN_FORCESHOWHIDDEN
 


### PR DESCRIPTION
Merged #239, added comments about weird Windows' behavior (i.e. falling on undefined items such as `My Computer` and even allowing it to do so!), win32gui behavior of most likely incorrectly handling types from file dialogs happening, etc.

Also, always log whatever bad happens, not just purge the exception.

Ref:
> function returns an array when files are selected, but returns a string when cancel/quit is selected

[source](https://stackoverflow.com/a/47571245/5994041), the logic behind it is seriously stupid, but anyway, it's most likely win32gui not handling that.

https://docs.microsoft.com/en-us/office/vba/api/Excel.Application.GetOpenFilename