### PR TITLE
Fixing Java class name

### DIFF
--- a/plyer/platforms/android/battery.py
+++ b/plyer/platforms/android/battery.py
@@ -22,7 +22,7 @@ class AndroidBattery(Battery):
         ifilter = INTENTFILTER(INTENT.ACTION_BATTERY_CHANGED)
 
         battery_status = cast(
-            'android.content.INTENT',
+            'android.content.Intent',
             activity.registerReceiver(None, ifilter)
         )
 


### PR DESCRIPTION
Looks like it has been broken by Auto replace of all "Intent" -> "INTENT" on Jul 10: https://github.com/kivy/plyer/commit/7ececb608dafb7663828d6cad6f45136e7c9fced#diff-8b8d9bc9ae852189c327adcd5e1f26ce