### PR TITLE
Add Linux Screenshot with X11's X Window Dump

### DIFF
--- a/Dockerfile.bionic.py2
+++ b/Dockerfile.bionic.py2
@@ -18,6 +18,9 @@ RUN apt-get update && \
     && apt-get -y autoremove \
     && apt-get -y clean
 
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
 # install PIP
 RUN wget https://bootstrap.pypa.io/2.6/get-pip.py -O get-pip2.py
 RUN python -V && \

--- a/Dockerfile.bionic.py2
+++ b/Dockerfile.bionic.py2
@@ -33,8 +33,7 @@ COPY devrequirements.txt .
 RUN python -m pip install \
         --upgrade \
         --requirement devrequirements.txt
-RUN python -m pip install \
-    https://github.com/kivy/pyjnius/zipball/master
+RUN python -m pip install pyjnius
 
 COPY . $APP_DIR
 RUN python -m pip install .

--- a/Dockerfile.bionic.py3
+++ b/Dockerfile.bionic.py3
@@ -18,6 +18,9 @@ RUN apt-get update && \
     && apt-get -y autoremove \
     && apt-get -y clean
 
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
 # install PIP
 RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip3.py
 RUN python3.6 -V && \

--- a/Dockerfile.bionic.py3
+++ b/Dockerfile.bionic.py3
@@ -33,8 +33,7 @@ COPY devrequirements.txt .
 RUN python3.6 -m pip install \
         --upgrade \
         --requirement devrequirements.txt
-RUN python3.6 -m pip install \
-    https://github.com/kivy/pyjnius/zipball/master
+RUN python3.6 -m pip install pyjnius
 
 COPY . $APP_DIR
 RUN python3.6 -m pip install .

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Notifications                      X           X       X    X
 Number of Processors                                        X
 Orientation                        X
 Proximity                          X
-Screenshot                                     X       X
+Screenshot                                     X       X    X
 Sms (send messages)                X       X
 Spatial Orientation                X       X
 Storage Path                       X       X   X       X    X

--- a/plyer/platforms/linux/screenshot.py
+++ b/plyer/platforms/linux/screenshot.py
@@ -1,0 +1,29 @@
+import subprocess
+from os.path import join
+from plyer.facades import Screenshot
+from plyer.utils import whereis_exe
+from plyer.platforms.linux.storagepath import LinuxStoragePath
+
+
+class LinuxScreenshot(Screenshot):
+    def __init__(self, file_path=None):
+        default_path = join(
+            LinuxStoragePath().get_pictures_dir(),
+            'screenshot.xwd'
+        )
+        super(LinuxScreenshot, self).__init__(file_path or default_path)
+
+    def _capture(self):
+        # call xwd and redirect bytes from stdout to file
+        with open(self.file_path, 'wb') as fle:
+            subprocess.call([
+                # quiet, full screen root window
+                'xwd', '-silent', '-root',
+            ], stdout=fle)
+
+
+def instance():
+    if whereis_exe('xwd'):
+        return LinuxScreenshot()
+    else:
+        return Screenshot()

--- a/plyer/tests/test_screenshot.py
+++ b/plyer/tests/test_screenshot.py
@@ -48,7 +48,7 @@ class MockedScreenCapture(object):
 class MockedXWD(object):
     '''
     Mocked object used instead of the console-like calling
-    of screencapture binary with parameters.
+    of X11 xwd binary with parameters.
     '''
     @staticmethod
     def whereis_exe(binary):
@@ -59,13 +59,18 @@ class MockedXWD(object):
         return binary == 'xwd'
 
     @staticmethod
-    def call(args):
+    def call(args, stdout):
         '''
         Mocked subprocess.call to check console parameters.
         '''
-        assert len(args) == 2, len(args)
+        assert len(args) == 3, args
         assert args[0] == 'xwd', args
-        assert args[1:] == ['-silent', '-root']
+        assert args[1:] == ['-silent', '-root'], args
+        assert stdout.name == join(
+            expanduser('~'), 'Pictures', 'screenshot.xwd'
+        ), stdout.name
+        with open(stdout.name, 'w') as scr:
+            scr.write('')
 
 
 class TestScreenshot(unittest.TestCase):
@@ -104,11 +109,8 @@ class TestScreenshot(unittest.TestCase):
         with patch(target='subprocess.call', new=MockedScreenCapture.call):
             self.assertIsNone(scr.capture())
 
-        scr_path = join(
-            expanduser('~'), 'Pictures', 'screenshot.png'
-        )
-        self.assertTrue(exists(scr_path))
-        remove(scr_path)
+        self.assertTrue(exists(scr.file_path))
+        remove(scr.file_path)
 
     @PlatformTest('linux')
     def test_screenshot_xwd(self):
@@ -132,11 +134,8 @@ class TestScreenshot(unittest.TestCase):
         with patch(target='subprocess.call', new=MockedXWD.call):
             self.assertIsNone(scr.capture())
 
-        scr_path = join(
-            expanduser('~'), 'Pictures', 'screenshot.png'
-        )
-        self.assertTrue(exists(scr_path))
-        remove(scr_path)
+        self.assertTrue(exists(scr.file_path))
+        remove(scr.file_path)
 
 
 if __name__ == '__main__':

--- a/plyer/tests/test_screenshot.py
+++ b/plyer/tests/test_screenshot.py
@@ -5,6 +5,7 @@ TestScreenshot
 Tested platforms:
 
 * MacOS
+* Linux
 '''
 
 import unittest
@@ -44,6 +45,29 @@ class MockedScreenCapture(object):
             scr.write('')
 
 
+class MockedXWD(object):
+    '''
+    Mocked object used instead of the console-like calling
+    of screencapture binary with parameters.
+    '''
+    @staticmethod
+    def whereis_exe(binary):
+        '''
+        Mock whereis_exe, so that it looks like
+        X11 xwd binary is present on the system.
+        '''
+        return binary == 'xwd'
+
+    @staticmethod
+    def call(args):
+        '''
+        Mocked subprocess.call to check console parameters.
+        '''
+        assert len(args) == 2, len(args)
+        assert args[0] == 'xwd', args
+        assert args[1:] == ['-silent', '-root']
+
+
 class TestScreenshot(unittest.TestCase):
     '''
     TestCase for plyer.screenshot.
@@ -78,6 +102,34 @@ class TestScreenshot(unittest.TestCase):
 
         # move capture from context manager to run without mock
         with patch(target='subprocess.call', new=MockedScreenCapture.call):
+            self.assertIsNone(scr.capture())
+
+        scr_path = join(
+            expanduser('~'), 'Pictures', 'screenshot.png'
+        )
+        self.assertTrue(exists(scr_path))
+        remove(scr_path)
+
+    @PlatformTest('linux')
+    def test_screenshot_xwd(self):
+        '''
+        Test mocked X11 xwd for plyer.screenshot.
+        '''
+        scr = platform_import(
+            platform='linux',
+            module_name='screenshot',
+            whereis_exe=MockedXWD.whereis_exe
+        )
+
+        # such class exists in screenshot module
+        self.assertIn('LinuxScreenshot', dir(scr))
+
+        # the required instance is created
+        scr = scr.instance()
+        self.assertIn('LinuxScreenshot', str(scr))
+
+        # move capture from context manager to run without mock
+        with patch(target='subprocess.call', new=MockedXWD.call):
             self.assertIsNone(scr.capture())
 
         scr_path = join(


### PR DESCRIPTION
Unless XDG locations are generated, our StoragePath implementation for GNU/Linux distros fails. Ref https://wiki.archlinux.org/index.php/XDG_user_directories.

`xwd` binary is present on all distros X server is used for backend. This approach is different than the previous implementations due to *not* converting the default `.XWD` format, therefore makes plyer independent on whatever converter a user might use (e.g. ImageMagick, PIL, xyz). IMO this implementation is the least evil of all as the binary is shipped with X server and we don't need to care for any Python wrappers for X C library or whatever random converter present on the system.

Most of the distros do have various file openers for that format e.g. ImageMagick, Gnome default image viewer, Gimp, etc etc which also support converting both from GUI and from console.

Closes #326