### PR TITLE
fetching device interface name (ifname)

### DIFF
--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -27,6 +27,10 @@ class LinuxWifi(Wifi):
             break
     else:
         ifname = "wlan0"
+        
+    com = Popen(["nmcli","--version"],stdout=PIPE)
+    com = com.communicate()[0].strip()
+    nmcliVersion = int(com.split(" ")[-1].replace(".", ""))
     
     def _is_enabled(self):
         '''
@@ -98,7 +102,10 @@ class LinuxWifi(Wifi):
         '''
         Disconnect all the networks managed by Network manager.
         '''
-        return call(['nmcli', 'nm', 'enable', 'false'])
+        if(self.nmcliVersion > 98):
+            return call(['nmcli','networking','off'])
+        else:
+            return call(['nmcli', 'nm', 'enable', 'false'])
 
 
 def instance():

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -18,7 +18,8 @@ from subprocess import Popen, PIPE, call
 class LinuxWifi(Wifi):
     names = {}
     
-    ifname = Popen(["nmcli", "-t","connection", "show", "--active"], stdout=PIPE, stderr=PIPE).communicate()[0].decode().split(":")[-1].strip()
+    Popen(["nmcli", "-t","connection", "show", "--active"], stdout=PIPE, stderr=PIPE).
+    ifname = communicate()[0].decode('utf-8').split(":")[-1].strip()
     
     def _is_enabled(self):
         '''

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -18,8 +18,15 @@ from subprocess import Popen, PIPE, call
 class LinuxWifi(Wifi):
     names = {}
     
-    Popen(["nmcli", "-t","connection", "show", "--active"], stdout=PIPE, stderr=PIPE).
-    ifname = communicate()[0].decode('utf-8').split(":")[-1].strip()
+    com = Popen(["nmcli", "-t","connection", "show", "--active","--order","active" ], stdout=PIPE )
+    com = com.communicate()[0].strip().split("\n")
+    for i in com:
+        if("wireless" in i):
+            ifname = i
+            ifname = ifname.split(':')[-1]
+            break
+    else:
+        ifname = "wlan0"
     
     def _is_enabled(self):
         '''

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -17,7 +17,9 @@ from subprocess import Popen, PIPE, call
 
 class LinuxWifi(Wifi):
     names = {}
-
+    
+    ifname = Popen(["nmcli", "-t","connection", "show", "--active"], stdout=PIPE, stderr=PIPE).communicate()[0].decode().split(":")[-1].strip()
+    
     def _is_enabled(self):
         '''
         Returns `True` if wifi is enabled else `False`.
@@ -32,7 +34,7 @@ class LinuxWifi(Wifi):
         Returns all the network information.
         '''
         if self._is_enabled():
-            list_ = wifi.Cell.all('wlan0')
+            list_ = wifi.Cell.all(self.ifname)
             for i in range(len(list_)):
                 self.names[list_[i].ssid] = list_[i]
         else:
@@ -80,7 +82,7 @@ class LinuxWifi(Wifi):
             password = parameters['password']
             cell = self.names[network]
             result = wifi.Scheme.for_cell(
-                'wlan0', network, cell, password
+                self.ifname, network, cell, password
             )
         return result
 


### PR DESCRIPTION
Now device interface supports the new naming scheme of a network interface. Hardcode interface name not needed anymore.