### PR TITLE
Add more distros via Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,37 @@ services:
 matrix:
     fast_finish: true
     include:
-        - env: DOCK=1 PY=2 RUN=unit
+        - env: DOCK=1 IMAGE=bionic PY=2 RUN=unit
           python: 2.7
           os: linux
           dist: trusty
 
-        - env: DOCK=1 PY=3 RUN=unit COVERALLS=1
+        - env: DOCK=1 IMAGE=bionic PY=3 RUN=unit COVERALLS=1
           python: 3.5
           os: linux
           dist: trusty
 
-        - env: DOCK=1 PY=3 RUN=style
+        - env: DOCK=1 IMAGE=bionic PY=3 RUN=style
+          python: 3.5
+          os: linux
+          dist: trusty
+
+        - env: DOCK=1 IMAGE=fedora28 PY=2 RUN=unit
+          python: 2.7
+          os: linux
+          dist: trusty
+
+        - env: DOCK=1 IMAGE=fedora28 PY=3 RUN=unit
+          python: 3.5
+          os: linux
+          dist: trusty
+
+        - env: DOCK=1 IMAGE=archlinux PY=2 RUN=unit
+          python: 2.7
+          os: linux
+          dist: trusty
+
+        - env: DOCK=1 IMAGE=archlinux PY=3 RUN=unit
           python: 3.5
           os: linux
           dist: trusty
@@ -60,18 +80,20 @@ install:
           if [ "$PY" == "2" ]; then
               docker build
                   --tag plyer:py2
-                  --file Dockerfile.bionic.py2
+                  --file Dockerfile.$IMAGE.py2
                   "$(pwd)";
           elif [ "$PY" == "3" ]; then
               docker build
                   --tag plyer:py3
-                  --file Dockerfile.bionic.py3
+                  --file Dockerfile.$IMAGE.py3
                   "$(pwd)";
 
-              docker build
-                  --tag plyer:style
-                  --file Dockerfile.bionic.style
-                  "$(pwd)";
+              if [ "$RUN" == "style" ]; then
+                  docker build
+                      --tag plyer:style
+                      --file Dockerfile.$IMAGE.style
+                      "$(pwd)";
+              fi;
           fi;
       fi;
 

--- a/Dockerfile.archlinux.py2
+++ b/Dockerfile.archlinux.py2
@@ -1,0 +1,43 @@
+FROM base/archlinux
+
+ENV APP_DIR=/app
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+ENV PYTHONPATH=$PYTHONPATH:$(pwd)
+
+# install default packages
+RUN pacman -Fy && \
+    pacman -Sy && \
+    yes |pacman -Sy \
+    gcc \
+    python2 \
+    jdk-openjdk \
+    lshw \
+    wget \
+    apparmor \
+    xdg-user-dirs \
+    && yes |pacman -Rns $(pacman -Qtdq) ||true \
+    && yes |pacman -Sc
+
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
+# install PIP
+RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
+RUN python2 -V && \
+    python2 get-pip.py && \
+    rm get-pip.py && \
+    python2 -m pip install --upgrade pip
+
+
+# install dev packages
+COPY devrequirements.txt .
+RUN python2 -m pip install \
+        --upgrade \
+        --requirement devrequirements.txt
+RUN python2 -m pip install pyjnius
+
+COPY . $APP_DIR
+RUN python2 -m pip install .
+ENV PYTHON=/usr/bin/python2
+ENTRYPOINT ["/app/entrypoint.sh", "env"]

--- a/Dockerfile.archlinux.py3
+++ b/Dockerfile.archlinux.py3
@@ -1,0 +1,41 @@
+FROM base/archlinux
+
+ENV APP_DIR=/app
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+ENV PYTHONPATH=$PYTHONPATH:$(pwd)
+
+# install default packages
+RUN pacman -Fy && \
+    pacman -Sy && \
+    yes |pacman -Sy \
+    gcc \
+    extra/python \
+    jdk-openjdk \
+    lshw \
+    wget \
+    apparmor \
+    xdg-user-dirs \
+    && yes |pacman -Rns $(pacman -Qtdq) ||true \
+    && yes |pacman -Sc
+
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
+# install PIP
+RUN wget https://bootstrap.pypa.io/get-pip.py -O get-pip3.py
+RUN python -V && \
+    python get-pip3.py && \
+    rm get-pip3.py && \
+    python -m pip install --upgrade pip
+
+# install dev packages
+COPY devrequirements.txt .
+RUN python -m pip install \
+        --upgrade \
+        --requirement devrequirements.txt
+RUN python -m pip install pyjnius
+
+COPY . $APP_DIR
+ENV PYTHON=/usr/bin/python
+ENTRYPOINT ["/app/entrypoint.sh", "env"]

--- a/Dockerfile.fedora28.py2
+++ b/Dockerfile.fedora28.py2
@@ -1,0 +1,39 @@
+FROM fedora:28
+
+ENV APP_DIR=/app
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+ENV PYTHONPATH=$PYTHONPATH:$(pwd)
+
+# install default packages
+# redhat-rpm-config: https://stackoverflow.com/a/34641068/5994041
+RUN yum -y install \
+    gcc \
+    python \
+    python-devel \
+    java-11-openjdk \
+    java-11-openjdk-devel \
+    lshw \
+    wget \
+    xdg-user-dirs \
+    redhat-rpm-config \
+    && yum -y autoremove \
+    && yum clean all
+
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
+# install PIP
+RUN python -V && \
+    python -m pip install --upgrade pip
+
+# install dev packages
+COPY devrequirements.txt .
+RUN python -m pip install \
+        --upgrade \
+        --requirement devrequirements.txt
+RUN python -m pip install pyjnius
+
+COPY . $APP_DIR
+RUN python -m pip install .
+ENTRYPOINT ["/app/entrypoint.sh", "py2"]

--- a/Dockerfile.fedora28.py3
+++ b/Dockerfile.fedora28.py3
@@ -1,0 +1,38 @@
+FROM fedora:28
+
+ENV APP_DIR=/app
+RUN mkdir $APP_DIR
+WORKDIR $APP_DIR
+ENV PYTHONPATH=$PYTHONPATH:$(pwd)
+
+# install default packages
+# redhat-rpm-config: https://stackoverflow.com/a/34641068/5994041
+RUN yum -y install \
+    gcc \
+    python3-devel \
+    java-11-openjdk \
+    java-11-openjdk-devel \
+    lshw \
+    wget \
+    xdg-user-dirs \
+    redhat-rpm-config \
+    && yum -y autoremove \
+    && yum clean all
+
+# generate user folder locations (Pictures, Downloads, ...)
+RUN xdg-user-dirs-update
+
+# install PIP
+RUN python3.6 -V && \
+    python3.6 -m pip install --upgrade pip
+
+# install dev packages
+COPY devrequirements.txt .
+RUN python3.6 -m pip install \
+        --upgrade \
+        --requirement devrequirements.txt
+RUN python3.6 -m pip install pyjnius
+
+COPY . $APP_DIR
+RUN python3.6 -m pip install .
+ENTRYPOINT ["/app/entrypoint.sh", "py3"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,9 +7,14 @@ then
 elif [ "$1" = "py3" ] || [ "$1" = "pep8" ]
 then
     PYTHON=$(which python3.6)
+elif [ "$1" = "env" ]
+then
+    PYTHON=$PYTHON
 else
     exit 1
 fi
+
+$PYTHON -V
 
 # pep8 check
 if [ "$2" = "style" ]


### PR DESCRIPTION
Add more GNU/Linux distros, so that we can test if a feature x, y, z works on the most common distros (or their bases) such as Arch for Arch, Manjaro, others and Fedora for RedHat distros. We already have Ubuntu (therefore Mint and perhaps even Debian) covered.

I'm using Fedora 28 due to yum/dnf bug which is rather old one.

Only one distro will be used for deployment and that's the one with the style tests, unit tests and even coveralls' coverage report (`COVERALLS=1`).