### PR TITLE
Fixed macOS using non-standard path for get_home_dir()

### DIFF
--- a/plyer/platforms/macosx/storagepath.py
+++ b/plyer/platforms/macosx/storagepath.py
@@ -24,7 +24,8 @@ class OSXStoragePath(StoragePath):
         self.defaultManager = NSFileManager.defaultManager()
 
     def _get_home_dir(self):
-        return os.path.expanduser('~')
+        home_dir_NSURL = self.defaultManager.homeDirectoryForCurrentUser
+        return home_dir_NSURL.absoluteString.UTF8String()
 
     def _get_external_storage_dir(self):
         return 'Method not implemented for current platform.'


### PR DESCRIPTION
Fixed macOS using non-standard path for get_home_dir().
Code now uses NSFileManager from macOS Objective-C API and gets the home directory path from its `homeDirectoryForCurrentUser` property (including `file://` URI scheme).

Resolves issue #450.