### PR TITLE
Fix uniqueid for linux platform

### DIFF
--- a/plyer/platforms/linux/uniqueid.py
+++ b/plyer/platforms/linux/uniqueid.py
@@ -16,12 +16,17 @@ class LinuxUniqueID(UniqueID):
     def _get_uid(self):
         old_lang = environ.get('LANG')
         environ['LANG'] = 'C'
-        lshw_process = Popen(["lshw", "-quiet"], stdout=PIPE, stderr=PIPE)
-        grep_process = Popen(["grep", "-m1", "serial:"],
-                             stdin=lshw_process.stdout, stdout=PIPE)
-        lshw_process.stdout.close()
-        output = grep_process.communicate()[0]
-        environ['LANG'] = old_lang
+        stdout = Popen(
+            ["lshw", "-quiet"],
+            stdout=PIPE, stderr=PIPE
+        ).communicate()[0].decode('utf-8')
+
+        output = u''
+        for line in stdout.splitlines():
+            if 'serial:' not in line:
+                continue
+            output = line
+            break
 
         environ['LANG'] = old_lang or u''
         result = None

--- a/plyer/platforms/linux/uniqueid.py
+++ b/plyer/platforms/linux/uniqueid.py
@@ -23,7 +23,9 @@ class LinuxUniqueID(UniqueID):
         output = grep_process.communicate()[0]
         environ['LANG'] = old_lang
 
+        environ['LANG'] = old_lang or u''
         result = None
+
         if output:
             result = output.split()[1]
         return result


### PR DESCRIPTION
`putenv()` fails if `None` is used which is the default if you want to get a value from a dictionary by a key. Also, another unnecessary `grep` purged along the way.