### PR TITLE
New extended CPU details implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Brightness                         X       X                X
 Call                               X       X
 Camera (taking picture)            X       X
 Compass                            X       X
-CPU count                                              X    X
+CPU count                                      X       X    X
 Email (open mail client)           X       X   X       X    X
 Flash                              X       X
 GPS                                X       X

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Brightness                         X       X                X
 Call                               X       X
 Camera (taking picture)            X       X
 Compass                            X       X
+CPU count                                              X    X
 Email (open mail client)           X       X   X       X    X
 Flash                              X       X
 GPS                                X       X
@@ -52,7 +53,6 @@ IR Blaster                         X
 Light                              X
 Native file chooser                            X       X    X
 Notifications                      X           X       X    X
-Number of Processors                                        X
 Orientation                        X
 Proximity                          X
 Screenshot                                     X       X    X

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -10,7 +10,7 @@ __all__ = ('accelerometer', 'audio', 'barometer', 'battery', 'call', 'camera',
            'gyroscope', 'irblaster', 'light', 'orientation', 'notification',
            'proximity', 'sms', 'tts', 'uniqueid', 'vibrator', 'wifi',
            'temperature', 'humidity', 'spatialorientation', 'brightness',
-           'storagepath', 'processors', 'bluetooth', 'screenshot')
+           'storagepath', 'processors', 'cpu', 'bluetooth', 'screenshot')
 
 __version__ = '1.3.3.dev0'
 
@@ -110,6 +110,9 @@ bluetooth = Proxy('bluetooth', facades.Bluetooth)
 
 #: Processors proxy to :class:`plyer.facades.Processors`
 processors = Proxy('processors', facades.Processors)
+
+#: Processors proxy to :class:`plyer.facades.CPU`
+cpu = Proxy('cpu', facades.CPU)
 
 #: Screenshot proxy to :class:`plyer.facades.Screenshot`
 screenshot = Proxy('screenshot', facades.Screenshot)

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -9,7 +9,7 @@ Interface of all the features available.
 __all__ = ('Accelerometer', 'Audio', 'Barometer', 'Battery', 'Call', 'Camera',
            'Compass', 'Email', 'FileChooser', 'GPS', 'Gravity', 'Gyroscope',
            'IrBlaster', 'Light', 'Orientation', 'Notification', 'Proximity',
-           'Sms', 'TTS', 'UniqueID', 'Vibrator', 'Wifi', 'Flash',
+           'Sms', 'TTS', 'UniqueID', 'Vibrator', 'Wifi', 'Flash', 'CPU',
            'Temperature', 'Humidity', 'SpatialOrientation', 'Brightness',
            'Processors', 'StoragePath', 'keystore', 'Bluetooth', 'Screenshot')
 
@@ -44,4 +44,5 @@ from plyer.facades.keystore import Keystore
 from plyer.facades.storagepath import StoragePath
 from plyer.facades.bluetooth import Bluetooth
 from plyer.facades.processors import Processors
+from plyer.facades.cpu import CPU
 from plyer.facades.screenshot import Screenshot

--- a/plyer/facades/cpu.py
+++ b/plyer/facades/cpu.py
@@ -1,0 +1,38 @@
+'''
+CPU count
+=========
+
+Simple Example
+---------------
+
+To get CPU count::
+    >>> from plyer import cpu
+    >>> cpu.cpus  # 1 core, 2 threads, logical = cores * threads
+    {'physical': 1, 'logical': 2}
+
+Supported Platforms
+-------------------
+
+Linux
+'''
+
+
+class CPU(object):
+    '''
+    Facade providing info about physical and logical number of processors.
+    '''
+
+    @property
+    def cpus(self):
+        '''
+        Property that contains a dict with the following fields:
+
+        * `physical` *(int)*: Total number of physical cores in the system.
+        * `logical` *(int)*: Total number of cores * threads in the system.
+        '''
+        return self._cpus()
+
+    # private
+
+    def _cpus(self):
+        raise NotImplementedError()

--- a/plyer/facades/cpu.py
+++ b/plyer/facades/cpu.py
@@ -20,6 +20,7 @@ Supported Platforms
 
 MacOS
 Linux
+Windows
 '''
 
 
@@ -56,6 +57,23 @@ class CPU(object):
         '''
         return self._logical()
 
+    @property
+    def cache(self):
+        '''
+        Property that contains the count of L1, L2, L3 caches in the system
+        as a dictionary `{'L1': int, 'L2': int, 'L3': int}`.
+        '''
+        return self._cache()
+
+    @property
+    def numa(self):
+        '''
+        Property that contains the count of NUMA nodes in the system.
+
+        .. note:: https://en.wikipedia.org/wiki/Non-uniform_memory_access
+        '''
+        return self._numa()
+
     # private
 
     def _sockets(self):
@@ -65,4 +83,10 @@ class CPU(object):
         raise NotImplementedError()
 
     def _logical(self):
+        raise NotImplementedError()
+
+    def _cache(self):
+        raise NotImplementedError()
+
+    def _numa(self):
         raise NotImplementedError()

--- a/plyer/facades/cpu.py
+++ b/plyer/facades/cpu.py
@@ -13,6 +13,7 @@ To get CPU count::
 Supported Platforms
 -------------------
 
+MacOS
 Linux
 '''
 

--- a/plyer/facades/cpu.py
+++ b/plyer/facades/cpu.py
@@ -1,14 +1,19 @@
 '''
-CPU count
-=========
+CPU
+===
 
 Simple Example
 ---------------
 
 To get CPU count::
     >>> from plyer import cpu
-    >>> cpu.cpus  # 1 core, 2 threads, logical = cores * threads
-    {'physical': 1, 'logical': 2}
+    >>> # 1 socket, 1 core per socket, 2 threads per core
+    >>> cpu.sockets   # 1 CPU socket (or slot)
+    1
+    >>> cpu.physical  # 1 CPU socket * 1 core per socket
+    1
+    >>> cpu.logical   # 1 CPU socket * 1 core per socket * 2 threads per core
+    2
 
 Supported Platforms
 -------------------
@@ -20,20 +25,44 @@ Linux
 
 class CPU(object):
     '''
-    Facade providing info about physical and logical number of processors.
+    Facade providing info about sockets, physical and logical
+    number of processors.
     '''
 
     @property
-    def cpus(self):
+    def sockets(self):
         '''
-        Property that contains a dict with the following fields:
+        Property that contains the count of CPU sockets.
+        '''
+        return self._sockets()
 
-        * `physical` *(int)*: Total number of physical cores in the system.
-        * `logical` *(int)*: Total number of cores * threads in the system.
+    @property
+    def physical(self):
         '''
-        return self._cpus()
+        Property that contains the total number of physical cores
+        (max core count) in the system.
+
+        .. note:: `sockets * cores per socket`
+        '''
+        return self._physical()
+
+    @property
+    def logical(self):
+        '''
+        Property that contains the total number of logical cores
+        (max thread count) in the system.
+
+        .. note:: `sockets * cores per socket * threads per core`
+        '''
+        return self._logical()
 
     # private
 
-    def _cpus(self):
+    def _sockets(self):
+        raise NotImplementedError()
+
+    def _physical(self):
+        raise NotImplementedError()
+
+    def _logical(self):
         raise NotImplementedError()

--- a/plyer/platforms/linux/cpu.py
+++ b/plyer/platforms/linux/cpu.py
@@ -1,11 +1,18 @@
+'''
+Module of Linux API for plyer.cpu.
+'''
+
+from os import environ
 from subprocess import Popen, PIPE
 from plyer.facades import CPU
 from plyer.utils import whereis_exe
 
-from os import environ
-
 
 class LinuxCPU(CPU):
+    '''
+    Implementation of Linux CPU API.
+    '''
+
     def _sockets(self):
         # physical CPU sockets (or slots) on motherboard
         sockets = []  # list of CPU ids from kernel
@@ -61,8 +68,19 @@ class LinuxCPU(CPU):
         environ['LANG'] = old_lang
         return logical
 
+    @staticmethod
+    def _cache():
+        return
+
+    @staticmethod
+    def _numa():
+        return
+
 
 def instance():
+    '''
+    Instance for facade proxy.
+    '''
     import sys
     if whereis_exe('nproc'):
         return LinuxCPU()

--- a/plyer/platforms/linux/cpu.py
+++ b/plyer/platforms/linux/cpu.py
@@ -5,20 +5,35 @@ from plyer.utils import whereis_exe
 from os import environ
 
 
-class LinuxProcessors(CPU):
-    def _cpus(self):
-        old_lang = environ.get('LANG', '')
-        environ['LANG'] = 'C'
+class LinuxCPU(CPU):
+    def _sockets(self):
+        # physical CPU sockets (or slots) on motherboard
+        sockets = []  # list of CPU ids from kernel
 
-        cpus = {
-            'physical': None,  # cores
-            'logical': None    # cores * threads
-        }
-
-        physical = []  # list of CPU ids from kernel
         # open Linux kernel data file for CPU
         with open('/proc/cpuinfo', 'rb') as fle:
             lines = fle.readlines()
+
+        # go through the lines and obtain physical CPU ids
+        for line in lines:
+            line = line.decode('utf-8')
+            if 'physical id' not in line:
+                continue
+            cpuid = line.split(':')[1].strip()
+            sockets.append(cpuid)
+
+        # total sockets is the length of unique CPU ids from kernel
+        sockets = len(set(sockets))
+        return sockets
+
+    def _physical(self):
+        # cores
+        physical = []  # list of CPU ids from kernel
+
+        # open Linux kernel data file for CPU
+        with open('/proc/cpuinfo', 'rb') as fle:
+            lines = fle.readlines()
+
         # go through the lines and obtain CPU core ids
         for line in lines:
             line = line.decode('utf-8')
@@ -26,27 +41,30 @@ class LinuxProcessors(CPU):
                 continue
             cpuid = line.split(':')[1].strip()
             physical.append(cpuid)
+
         # total cores (socket * core per socket)
-        # is the length of unique CPU ids from kernel
+        # is the length of unique CPU core ids from kernel
         physical = len(set(physical))
-        cpus['physical'] = physical
+        return physical
 
-        logical = Popen(
-            ['nproc', '--all'],
-            stdout=PIPE
-        )
-        output = logical.communicate()[0].decode('utf-8').strip()
+    def _logical(self):
+        # cores * threads
+        logical = None
+        old_lang = environ.get('LANG', '')
+        environ['LANG'] = 'C'
 
+        _logical = Popen(['nproc', '--all'], stdout=PIPE)
+        output = _logical.communicate()[0].decode('utf-8').strip()
         if output:
-            cpus['logical'] = int(output)
+            logical = int(output)
 
         environ['LANG'] = old_lang
-        return cpus
+        return logical
 
 
 def instance():
     import sys
     if whereis_exe('nproc'):
-        return LinuxProcessors()
+        return LinuxCPU()
     sys.stderr.write("nproc not found.")
     return CPU()

--- a/plyer/platforms/linux/cpu.py
+++ b/plyer/platforms/linux/cpu.py
@@ -1,0 +1,35 @@
+from subprocess import Popen, PIPE
+from plyer.facades import CPU
+from plyer.utils import whereis_exe
+
+from os import environ
+
+
+class LinuxProcessors(CPU):
+    def _cpus(self):
+        old_lang = environ.get('LANG', '')
+        environ['LANG'] = 'C'
+
+        cpus = {
+            'physical': None,  # cores
+            'logical': None    # cores * threads
+        }
+
+        logical = Popen(
+            ['nproc', '--all'],
+            stdout=PIPE
+        )
+        output = logical.communicate()[0].decode('utf-8').strip()
+
+        environ['LANG'] = old_lang
+        if output:
+            cpus['logical'] = int(output)
+        return cpus
+
+
+def instance():
+    import sys
+    if whereis_exe('nproc'):
+        return LinuxProcessors()
+    sys.stderr.write("nproc not found.")
+    return CPU()

--- a/plyer/platforms/macosx/cpu.py
+++ b/plyer/platforms/macosx/cpu.py
@@ -1,0 +1,36 @@
+from subprocess import Popen, PIPE
+from plyer.facades import CPU
+from plyer.utils import whereis_exe
+
+
+class OSXProcessors(CPU):
+    def _cpus(self):
+        cpus = {
+            'physical': None,  # cores
+            'logical': None    # cores * threads
+        }
+
+        physical = Popen(
+            ['sysctl', '-n', 'hw.physicalcpu_max'],
+            stdout=PIPE
+        )
+        output = physical.communicate()[0].decode('utf-8').strip()
+        if output:
+            cpus['physical'] = int(output)
+
+        logical = Popen(
+            ['sysctl', '-n', 'hw.logicalcpu_max'],
+            stdout=PIPE
+        )
+        output = logical.communicate()[0].decode('utf-8').strip()
+        if output:
+            cpus['logical'] = int(output)
+        return cpus
+
+
+def instance():
+    import sys
+    if whereis_exe('sysctl'):
+        return OSXProcessors()
+    sys.stderr.write('sysctl not found.')
+    return CPU()

--- a/plyer/platforms/macosx/cpu.py
+++ b/plyer/platforms/macosx/cpu.py
@@ -3,34 +3,37 @@ from plyer.facades import CPU
 from plyer.utils import whereis_exe
 
 
-class OSXProcessors(CPU):
-    def _cpus(self):
-        cpus = {
-            'physical': None,  # cores
-            'logical': None    # cores * threads
-        }
+class OSXCPU(CPU):
+    def _physical(self):
+        # cores
+        physical = None
 
-        physical = Popen(
+        _physical = Popen(
             ['sysctl', '-n', 'hw.physicalcpu_max'],
             stdout=PIPE
         )
-        output = physical.communicate()[0].decode('utf-8').strip()
+        output = _physical.communicate()[0].decode('utf-8').strip()
         if output:
-            cpus['physical'] = int(output)
+            physical = int(output)
+        return physical
 
-        logical = Popen(
+    def _logical(self):
+        # cores * threads
+        logical = None
+
+        _logical = Popen(
             ['sysctl', '-n', 'hw.logicalcpu_max'],
             stdout=PIPE
         )
-        output = logical.communicate()[0].decode('utf-8').strip()
+        output = _logical.communicate()[0].decode('utf-8').strip()
         if output:
-            cpus['logical'] = int(output)
-        return cpus
+            logical = int(output)
+        return logical
 
 
 def instance():
     import sys
     if whereis_exe('sysctl'):
-        return OSXProcessors()
+        return OSXCPU()
     sys.stderr.write('sysctl not found.')
     return CPU()

--- a/plyer/platforms/macosx/cpu.py
+++ b/plyer/platforms/macosx/cpu.py
@@ -1,9 +1,21 @@
+'''
+Module of MacOS API for plyer.cpu.
+'''
+
 from subprocess import Popen, PIPE
 from plyer.facades import CPU
 from plyer.utils import whereis_exe
 
 
 class OSXCPU(CPU):
+    '''
+    Implementation of MacOS CPU API.
+    '''
+
+    @staticmethod
+    def _sockets():
+        return
+
     def _physical(self):
         # cores
         physical = None
@@ -30,8 +42,19 @@ class OSXCPU(CPU):
             logical = int(output)
         return logical
 
+    @staticmethod
+    def _cache():
+        return
+
+    @staticmethod
+    def _numa():
+        return
+
 
 def instance():
+    '''
+    Instance for facade proxy.
+    '''
     import sys
     if whereis_exe('sysctl'):
         return OSXCPU()

--- a/plyer/platforms/win/cpu.py
+++ b/plyer/platforms/win/cpu.py
@@ -1,0 +1,221 @@
+import ctypes
+from ctypes import (
+    c_uint, c_ulonglong, c_ulong, byref, pointer,
+    Structure, POINTER, Union, windll, create_string_buffer,
+    sizeof, cast, c_void_p, c_ulong, c_uint32
+)
+from ctypes.wintypes import (
+    BYTE, DWORD, WORD, BOOL
+)
+from plyer.facades import CPU
+
+from os import environ
+
+
+KERNEL = windll.kernel32
+ERROR_INSUFFICIENT_BUFFER = 0x0000007A
+
+
+class CacheType(object):
+    unified = 0
+    instruction = 1
+    data = 2
+    trace = 3
+
+
+class RelationshipType(object):
+    processor_core = 0     # logical proc sharing single core
+    numa_node = 1          # logical proc sharing single NUMA node
+    cache = 2              # logical proc sharing cache
+    processor_package = 3  # logical proc sharing physical package
+    group = 4              # logical proc sharing processor group
+    all = 0xffff           # logical proc info for all groups
+
+
+class CacheDescriptor(Structure):  # = 12
+    _fields_ = [
+        ("Level", BYTE),          # 1
+        ("Associativity", BYTE),  # 1
+        ("LineSize", WORD),       # 2
+        ("Size", DWORD),          # 4
+        ("Type", DWORD)           # 4
+    ]
+
+
+class ProcessorCore(Structure):  # = 1
+    _fields_ = [
+        ("Flags", BYTE)  # 1
+    ]
+
+
+class NumaNode(Structure):  # = 4
+    _fields_ = [
+        ("NodeNumber", DWORD)  # 4
+    ]
+
+
+class SystemLPIUnion(Union):  # = 25
+    _fields_ = [
+        ("ProcessorCore", ProcessorCore),  # 1
+        ("NumaNode", NumaNode),            # 4
+        ("Cache", CacheDescriptor),        # 12
+        ("Reserved", c_ulonglong)          # 8
+    ]
+
+
+class SystemLPI(Structure):  # = 48
+    _fields_ = [
+        ("ProcessorMask", c_ulong),  # 8
+        ("Relationship", c_ulong),   # 8
+        ("LPI", SystemLPIUnion)      # 24
+    ]
+
+
+class WinCPU(CPU):
+    def _countbits(self, mask):
+        # make sure the correct ULONG_PTR size is used on 64bit
+        # https://docs.microsoft.com/en-us/windows/
+        # desktop/WinProg/windows-data-types
+        # note: not a pointer per-se, != PULONG_PTR
+        ulong_ptr = c_ulonglong if sizeof(c_void_p) == 8 else c_ulong
+        # note: c_ulonglong only on 64bit, otherwise c_ulong
+
+        # DWORD == c_uint32
+        # https://docs.microsoft.com/en-us/windows/
+        # desktop/WinProg/windows-data-types
+        lshift = c_uint32(sizeof(ulong_ptr) * 8 - 1)
+        assert lshift.value in (31, 63), lshift  # 32 or 64 bits - 1
+
+        lshift = lshift.value
+        test = 1 << lshift
+        assert test % 2 == 0, test
+
+        count = 0
+        i = 0
+        while i <= lshift:
+            i += 1
+
+            # do NOT remove!!!
+            # test value has to be %2 == 0,
+            # except the last case where the value is 1,
+            # so that int(test) == int(float(test))
+            # and the mask bit is counted correctly
+            assert test % 2 == 0 or float(test) == 1.0, test
+
+            # https://stackoverflow.com/a/1746642/5994041
+            # note: useful to print(str(bin(int(...)))[2:])
+            count += 1 if (mask & int(test)) else 0
+            test /= 2
+
+        return count
+
+    def _logprocinfo(self, relationship):
+        value = None
+        mask_value = None
+        get_logical_process_info = KERNEL.GetLogicalProcessorInformation
+
+        # first call with no structure to get the real size of the required
+        buff_length = c_ulong(0)
+        result = get_logical_process_info(None, byref(buff_length))
+        assert not result, result
+        error = KERNEL.GetLastError()
+        assert error == ERROR_INSUFFICIENT_BUFFER, error
+        assert buff_length, buff_length
+
+        # create buffer from the real winapi buffer length
+        buff = create_string_buffer(buff_length.value)
+
+        # call again with buffer pointer + the same length as arguments
+        result = get_logical_process_info(buff, byref(buff_length))
+        assert result, (result, KERNEL.GetLastError())
+
+        # memory size of one LPI struct in the array of LPI structs
+        offset = sizeof(SystemLPI)  # ok
+        values = {
+            key: 0 for key in (
+                'relationship', 'mask',
+                'L1', 'L2', 'L3'
+            )
+        }
+        mask_value = 0
+
+        for i in range(0, buff_length.value, offset):
+            slpi = cast(
+                buff[i: i + offset],
+                POINTER(SystemLPI)
+            ).contents
+
+            if slpi.Relationship != relationship:
+                continue
+
+            values['relationship'] += 1
+            values['mask'] += self._countbits(slpi.ProcessorMask)
+
+            if slpi.LPI.Cache.Level == 1:
+                values['L1'] += 1
+            elif slpi.LPI.Cache.Level == 2:
+                values['L2'] += 1
+            elif slpi.LPI.Cache.Level == 3:
+                values['L3'] += 1
+
+        return values
+
+    def _sockets(self):
+        # physical CPU sockets (or slots) on motherboard
+        return self._logprocinfo(
+            RelationshipType.processor_package
+        )['relationship']
+
+    def _physical(self):
+        # cores
+        return self._logprocinfo(
+            RelationshipType.processor_core
+        )['relationship']
+
+    def _logical(self):
+        # cores * threads
+        # if hyperthreaded core -> more than one logical processor
+        return self._logprocinfo(
+            RelationshipType.processor_core
+        )['mask']
+
+    def _cache(self):
+        # L1, L2, L3 cache count
+        result = self._logprocinfo(
+            RelationshipType.cache
+        )
+        return {
+            key: result[key]
+            for key in result
+            if key in ('L1', 'L2', 'L3')
+        }
+
+    def _numa(self):
+        # numa nodes
+        return self._logprocinfo(
+            RelationshipType.numa_node
+        )['relationship']
+
+
+def instance():
+    return WinCPU()
+
+
+# Resources:
+# GetLogicalProcessInformation
+# https://msdn.microsoft.com/en-us/library/ms683194(v=vs.85).aspx
+
+# SYSTEM_LOGICAL_PROCESSOR_INFORMATION
+# https://msdn.microsoft.com/en-us/library/ms686694(v=vs.85).aspx
+
+# LOGICAL_PROCESSOR_RELATIONSHIP enum (0 - 4, 0xffff)
+# https://msdn.microsoft.com/2ada52f0-70ec-4146-9ef7-9af3b08996f9
+
+# CACHE_DESCRIPTOR struct
+# https://msdn.microsoft.com/38cfa605-831c-45ef-a99f-55f42b2b56e9
+
+# PROCESSOR_CACHE_TYPE
+# https://msdn.microsoft.com/23044f67-e944-43c2-8c75-3d2fba87cb3c
+
+# C example
+# https://msdn.microsoft.com/en-us/904d2d35-f419-4e8f-a689-f39ed926644c

--- a/plyer/tests/common.py
+++ b/plyer/tests/common.py
@@ -9,6 +9,8 @@ Common objects for testing
 '''
 
 import traceback
+from os import sep
+from os.path import normpath, splitdrive
 from plyer.utils import platform as plyer_platform
 
 
@@ -59,3 +61,18 @@ def platform_import(platform, module_name, whereis_exe=None):
     if whereis_exe:
         mod.whereis_exe = whereis_exe
     return mod
+
+
+def splitpath(path):
+    '''
+    Split string path into a list of folders (+ file if available).
+    '''
+    if path[0] == sep and path[1] != sep:
+        path = path[1:]
+        path = normpath(path).split(sep)
+    else:
+        drive, path = splitdrive(path)
+        if path[0] == sep and path[1] != sep:
+            path = path[1:]
+        path = [drive, ] + normpath(path).split(sep)
+    return path

--- a/plyer/tests/test_cpu.py
+++ b/plyer/tests/test_cpu.py
@@ -1,0 +1,79 @@
+'''
+TestCPU
+=======
+
+Tested platforms:
+
+* Linux - nproc
+'''
+
+import unittest
+
+from plyer.tests.common import PlatformTest, platform_import
+
+
+class MockedNProc(object):
+    '''
+    Mocked object used instead of 'nproc' binary in the Linux specific API
+    plyer.platforms.linux.cpu. The same output structure is tested for
+    the range of <min_version, max_version>.
+
+    .. note:: Extend the object with another data sample if it does not match.
+    '''
+
+    min_version = '8.21'
+    max_version = '8.21'
+    logical_cores = 99
+
+    def __init__(self, *args, **kwargs):
+        # only to ignore all args, kwargs
+        pass
+
+    @staticmethod
+    def communicate():
+        '''
+        Mock Popen.communicate, so that 'nproc' isn't used.
+        '''
+        return (str(MockedNProc.logical_cores).encode('utf-8'), )
+
+    @staticmethod
+    def whereis_exe(binary):
+        '''
+        Mock whereis_exe, so that it looks like
+        Linux NProc binary is present on the system.
+        '''
+        return binary == 'nproc'
+
+    @staticmethod
+    def logical():
+        '''
+        Return percentage from mocked data.
+        '''
+        return int(MockedNProc.logical_cores)
+
+
+class TestCPU(unittest.TestCase):
+    '''
+    TestCase for plyer.cpu.
+    '''
+
+    @PlatformTest('linux')
+    def test_cpu_linux_logical(self):
+        '''
+        Test mocked Linux NProc for plyer.cpu.
+        '''
+        cpu = platform_import(
+            platform='linux',
+            module_name='cpu',
+            whereis_exe=MockedNProc.whereis_exe
+        )
+        cpu.Popen = MockedNProc
+        cpu = cpu.instance()
+
+        self.assertEqual(
+            cpu.logical, MockedNProc.logical()
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plyer/tests/test_cpu.py
+++ b/plyer/tests/test_cpu.py
@@ -8,8 +8,11 @@ Tested platforms:
 * Linux - nproc
 '''
 
+import sys
 import unittest
 from os import environ
+from mock import patch, Mock
+from textwrap import dedent
 
 from plyer.tests.common import PlatformTest, platform_import
 
@@ -54,12 +57,97 @@ class MockedNProc(object):
         return int(MockedNProc.logical_cores)
 
 
+class MockedProcinfo(object):
+    # docs:
+    # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    # /tree/arch/x86/kernel/cpu/proc.c
+    sockets = 1  # physical id
+    physical = 2  # core id
+    threads_per_core = 2  # Intel specs document for i7-4500U
+    logical = physical * threads_per_core  # processor
+
+    def __init__(self, *args, **kwargs):
+        self.fname = args[0] if args else ''
+
+        self.output = []
+        __step = 0  # 0,1,0,1 -> 0,0,1,1
+        for soc in range(self.sockets):
+            for log in range(self.logical):
+                if log != 0 and not log % self.physical:
+                    __step += 1
+                self.output.append((dedent(
+                    '''\
+                    processor\t: {logical}
+                    vendor_id\t: GenuineIntel
+                    cpu family\t: 6
+                    model\t\t: 69
+                    model name\t: Intel(R) Core(TM) i7-4500U CPU @ 1.80GHz
+                    stepping\t: 1
+                    microcode\t: 0x17
+                    cpu MHz\t\t: 774.000
+                    cache size\t: 4096 KB
+                    physical id\t: {socket}
+                    siblings\t: 4
+                    core id\t\t: {physical}
+                    cpu cores\t: {threads_per_core}
+                    apicid\t\t: {logical}
+                    initial apicid\t: 0
+                    fpu\t\t: yes
+                    fpu_exception\t: yes
+                    cpuid level\t: 13
+                    wp\t\t: yes
+                    flags\t\t: fpu vme de pse tsc msr pae mce cx8 ...
+                    bogomips\t: 3591.40
+                    clflush size\t: 64
+                    cache_alignment\t: 64
+                    address sizes\t: 39 bits physical, 48 bits virtual
+                    power management:
+                    \n'''
+                )).format(**{
+                    'socket': soc,
+                    'physical': __step,
+                    'logical': log,
+                    'threads_per_core': self.threads_per_core
+                }))
+        self.output = ''.join(self.output).encode('utf-8')
+
+    def __enter__(self, *args):
+        file_value = None
+
+        if self.fname == '/proc/cpuinfo':
+            file_value = Mock()
+            file_value.readlines.return_value = self.output.split(
+                '\n'.encode('utf-8')
+            )
+        return file_value
+
+    def __exit__(self, *args):
+        pass
+
+
 class TestCPU(unittest.TestCase):
     '''
     TestCase for plyer.cpu.
     '''
 
-    @PlatformTest('linux')
+    def test_cpu_linux_physical(self):
+        cpu = platform_import(
+            platform='linux',
+            module_name='cpu',
+            whereis_exe=lambda b: b == 'nproc'
+        ).instance()
+
+        stub = MockedProcinfo
+        py2_target = '__builtin__.open'
+        py3_target = 'builtins.open'
+        target = py3_target if sys.version_info.major == 3 else py2_target
+
+        with patch(target=target, new=stub):
+            sb = stub()
+            self.assertEqual(
+                cpu.physical, sb.physical
+            )
+
     def test_cpu_linux_logical(self):
         '''
         Test mocked Linux NProc for plyer.cpu.

--- a/plyer/tests/test_cpu.py
+++ b/plyer/tests/test_cpu.py
@@ -4,10 +4,12 @@ TestCPU
 
 Tested platforms:
 
+* Windows
 * Linux - nproc
 '''
 
 import unittest
+from os import environ
 
 from plyer.tests.common import PlatformTest, platform_import
 
@@ -72,6 +74,21 @@ class TestCPU(unittest.TestCase):
 
         self.assertEqual(
             cpu.logical, MockedNProc.logical()
+        )
+
+    @PlatformTest('win')
+    def test_cpu_win_logical(self):
+        cpu = platform_import(
+            platform='win',
+            module_name='cpu'
+        )
+
+        cpu = cpu.instance()
+        self.assertEqual(
+            cpu.logical,
+            # https://docs.microsoft.com/en-us/previous-versions/
+            # windows/it-pro/windows-xp/bb490954(v=technet.10)
+            int(environ['NUMBER_OF_PROCESSORS'])
         )
 
 


### PR DESCRIPTION
This one gives actually an explanation what the returned value means + separates the values into properties/methods:

* sockets (couldn't find for OSX yet, let's assume 1 slot for now)
* physical
* logical
* cache (Win + Lin for now)
* numa (Win only for now)

Some tests are still WIP because of mocking objects from ctypes and/or finding an official command/value such as `%NUMBER_OF_PROCESSORS%`.

Deprecating `processors` if anyone used it.

ref #419 