### PR TITLE
Add support for interfaces in Linux WiFi

### DIFF
--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -103,11 +103,11 @@ class Wifi(object):
 
         raise NotImplementedError()
 
-    def start_scanning(self):
+    def start_scanning(self, interface=None):
         '''
         Turn on scanning.
         '''
-        return self._start_scanning()
+        return self._start_scanning(interface=interface)
 
     def get_network_info(self, name):
         '''
@@ -121,17 +121,21 @@ class Wifi(object):
         '''
         return self._get_available_wifi()
 
-    def connect(self, network, parameters):
+    def connect(self, network, parameters, interface=None):
         '''
         Method to connect to some network.
         '''
-        self._connect(network=network, parameters=parameters)
+        self._connect(
+            network=network,
+            parameters=parameters,
+            interface=interface
+        )
 
-    def disconnect(self):
+    def disconnect(self, interface=None):
         '''
         To disconnect from some network.
         '''
-        self._disconnect()
+        self._disconnect(interface=interface)
 
     def enable(self):
         '''

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -93,6 +93,14 @@ class Wifi(object):
         '''
         return self._is_enabled()
 
+    def is_connected(self, interface=None):
+        '''
+        Return connection state of WiFi interface.
+
+        .. versionadded:: 1.3.3
+        '''
+        return self._is_connected(interface=interface)
+
     @property
     def interfaces(self):
         '''
@@ -152,6 +160,9 @@ class Wifi(object):
     # private
 
     def _is_enabled(self):
+        raise NotImplementedError()
+
+    def _is_connected(self):
         raise NotImplementedError()
 
     def _start_scanning(self):

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -89,7 +89,7 @@ class Wifi(object):
 
     def is_enabled(self):
         '''
-        Returns `True`if the Wifi is enables else `False`.
+        Return enabled status of WiFi hardware.
         '''
         return self._is_enabled()
 

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -162,10 +162,10 @@ class Wifi(object):
     def _is_enabled(self):
         raise NotImplementedError()
 
-    def _is_connected(self):
+    def _is_connected(self, interface=None):
         raise NotImplementedError()
 
-    def _start_scanning(self):
+    def _start_scanning(self, interface=None):
         raise NotImplementedError()
 
     def _get_network_info(self, **kwargs):
@@ -177,7 +177,7 @@ class Wifi(object):
     def _connect(self, **kwargs):
         raise NotImplementedError()
 
-    def _disconnect(self):
+    def _disconnect(self, interface=None):
         raise NotImplementedError()
 
     def _enable(self):

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -93,6 +93,16 @@ class Wifi(object):
         '''
         return self._is_enabled()
 
+    @property
+    def interfaces(self):
+        '''
+        List all available WiFi interfaces.
+
+        .. versionadded:: 1.3.3
+        '''
+
+        raise NotImplementedError()
+
     def start_scanning(self):
         '''
         Turn on scanning.

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -63,7 +63,7 @@ class LinuxWifi(Wifi):
             return True
         return False
 
-    def _start_scanning(self):
+    def _start_scanning(self, interface=None):
         '''
         Returns all the network information.
 
@@ -71,9 +71,13 @@ class LinuxWifi(Wifi):
         .. versionchanged:: 1.3.0
             scan only if wifi is enabled
         '''
+
+        if not interface:
+            interface = self.interfaces[0]
+
         import wifi
         if self._is_enabled():
-            list_ = list(wifi.Cell.all('wlan0'))
+            list_ = list(wifi.Cell.all(interface))
             for i in range(len(list_)):
                 self.names[list_[i].ssid] = list_[i]
         else:
@@ -110,7 +114,7 @@ class LinuxWifi(Wifi):
         '''
         return self.names.keys()
 
-    def _connect(self, network, parameters):
+    def _connect(self, network, parameters, interface=None):
         '''
         Expects 2 parameters:
             - name/ssid of the network.
@@ -119,6 +123,9 @@ class LinuxWifi(Wifi):
 
         .. versionadded:: 1.2.5
         '''
+        if not interface:
+            interface = self.interfaces[0]
+
         import wifi
         result = None
         try:
@@ -127,18 +134,21 @@ class LinuxWifi(Wifi):
             password = parameters['password']
             cell = self.names[network]
             result = wifi.Scheme.for_cell(
-                'wlan0', network, cell, password
+                interface, network, cell, password
             )
         return result
 
-    def _disconnect(self):
+    def _disconnect(self, interface=None):
         '''
         Disconnect all the networks managed by Network manager.
 
         .. versionadded:: 1.2.5
         '''
+        if not interface:
+            interface = self.interfaces[0]
+
         if self._nmcli_version() >= (1, 2, 6):
-            call(['nmcli', 'dev', 'disconnect', 'wlan0'])
+            call(['nmcli', 'dev', 'disconnect', interface])
         else:
             call(['nmcli', 'nm', 'enable', 'false'])
 

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -140,15 +140,17 @@ class LinuxWifi(Wifi):
         Returns the name of available networks.
 
         .. versionadded:: 1.2.5
+        .. versionchanged:: 1.3.3
+            return a proper list of elements instead of dict_keys
         '''
-        return self.names.keys()
+        return list(self.names.keys())
 
     def _connect(self, network, parameters, interface=None):
         '''
         Expects 2 parameters:
             - name/ssid of the network.
-            - parameters:
-                - password: dict type
+            - parameters: dict type
+                - password: string or None
 
         .. versionadded:: 1.2.5
         '''

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -16,7 +16,9 @@ from subprocess import Popen, PIPE, call
 
 
 class LinuxWifi(Wifi):
-    names = {}
+    def __init__(self, *args, **kwargs):
+        super(LinuxWifi, self).__init__(*args, **kwargs)
+        self.names = {}
 
     @property
     def interfaces(self):

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -63,6 +63,35 @@ class LinuxWifi(Wifi):
             return True
         return False
 
+    def _is_connected(self, interface=None):
+        '''
+        .. versionadded:: 1.3.3
+        '''
+
+        if not interface:
+            interface = self.interfaces[0]
+
+        proc = Popen([
+            'nmcli', '--terse',
+            '--fields', 'DEVICE,TYPE,STATE',
+            'device'
+        ], stdout=PIPE)
+        lines = proc.communicate()[0].decode('utf-8').splitlines()
+
+        connected = False
+        for line in lines:
+            device, dtype, state = line.split(':')
+            if dtype != 'wifi':
+                continue
+
+            if device != interface:
+                continue
+
+            if state == 'connected':
+                connected = True
+
+        return connected
+
     def _start_scanning(self, interface=None):
         '''
         Returns all the network information.

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -18,6 +18,24 @@ from subprocess import Popen, PIPE, call
 class LinuxWifi(Wifi):
     names = {}
 
+    @property
+    def interfaces(self):
+        proc = Popen([
+            'nmcli', '--terse',
+            '--fields', 'DEVICE,TYPE',
+            'device'
+        ], stdout=PIPE)
+        lines = proc.communicate()[0].decode('utf-8').splitlines()
+
+        interfaces = []
+        for line in lines:
+            device, dtype = line.split(':')
+            if dtype != 'wifi':
+                continue
+            interfaces.append(device)
+
+        return interfaces
+
     def _is_enabled(self):
         '''
         Returns `True` if wifi is enabled else `False`.

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -16,12 +16,24 @@ from subprocess import Popen, PIPE, call
 
 
 class LinuxWifi(Wifi):
+    '''
+    .. versionadded:: 1.2.5
+    '''
+
     def __init__(self, *args, **kwargs):
+        '''
+        .. versionadded:: 1.3.3
+        '''
+
         super(LinuxWifi, self).__init__(*args, **kwargs)
         self.names = {}
 
     @property
     def interfaces(self):
+        '''
+        .. versionadded:: 1.3.3
+        '''
+
         proc = Popen([
             'nmcli', '--terse',
             '--fields', 'DEVICE,TYPE',
@@ -41,6 +53,10 @@ class LinuxWifi(Wifi):
     def _is_enabled(self):
         '''
         Returns `True` if wifi is enabled else `False`.
+
+        .. versionadded:: 1.2.5
+        .. versionchanged:: 1.3.2
+            nmcli output is properly decoded to unicode
         '''
         enbl = Popen(["nmcli", "radio", "wifi"], stdout=PIPE, stderr=PIPE)
         if enbl.communicate()[0].split()[0].decode('utf-8') == "enabled":
@@ -50,6 +66,10 @@ class LinuxWifi(Wifi):
     def _start_scanning(self):
         '''
         Returns all the network information.
+
+        .. versionadded:: 1.2.5
+        .. versionchanged:: 1.3.0
+            scan only if wifi is enabled
         '''
         import wifi
         if self._is_enabled():
@@ -63,6 +83,8 @@ class LinuxWifi(Wifi):
         '''
         Starts scanning for available Wi-Fi networks and returns the available,
         devices.
+
+        .. versionadded:: 1.2.5
         '''
         ret_list = {}
         ret_list['ssid'] = self.names[name].ssid
@@ -83,6 +105,8 @@ class LinuxWifi(Wifi):
     def _get_available_wifi(self):
         '''
         Returns the name of available networks.
+
+        .. versionadded:: 1.2.5
         '''
         return self.names.keys()
 
@@ -92,6 +116,8 @@ class LinuxWifi(Wifi):
             - name/ssid of the network.
             - parameters:
                 - password: dict type
+
+        .. versionadded:: 1.2.5
         '''
         import wifi
         result = None
@@ -108,6 +134,8 @@ class LinuxWifi(Wifi):
     def _disconnect(self):
         '''
         Disconnect all the networks managed by Network manager.
+
+        .. versionadded:: 1.2.5
         '''
         if self._nmcli_version() >= (1, 2, 6):
             call(['nmcli', 'dev', 'disconnect', 'wlan0'])
@@ -117,16 +145,23 @@ class LinuxWifi(Wifi):
     def _enable(self):
         '''
         Wifi interface power state is set to "ON".
+
+        .. versionadded:: 1.3.2
         '''
         return call(['nmcli', 'radio', 'wifi', 'on'])
 
     def _disable(self):
         '''
         Wifi interface power state is set to "OFF".
+
+        .. versionadded:: 1.3.2
         '''
         return call(['nmcli', 'radio', 'wifi', 'off'])
 
     def _nmcli_version(self):
+        '''
+        .. versionadded:: 1.3.2
+        '''
         version = Popen(['nmcli', '-v'], stdout=PIPE)
         version = version.communicate()[0].decode('utf-8')
         while version and not version[0].isdigit():


### PR DESCRIPTION
Previously we used `wlan0` which is not guaranteed to be even available on multiple distros/kernel versions, therefore using `wlan0` would fail with not available interface for any command. For example I have interface on one of my machines `wlpXsY`, therefore if anything, it'll fail with a different error.

The default behavior is to use the first listed interface retrieved by `nmcli` in case someone wants to create multiple interfaces / has more than one WiFi card (that's the main reason for `interface=None` optional kwargs). I have only one card and one interface though, therefore I haven't figured out how to retrieve a "primary" wifi interface. If anyone finds out, feel free to let me know or open an issue/PR.

WiFi connecting, disconnecting and anything with `import wifi` lines in it is on GNU/Linux broken due to importing an unfortunately named third-party package (#487) that collides basically with everything and needs to be rewritten.