### PR TITLE
Fix OSX builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ matrix:
 before_install:
     - echo PATH=$PATH;
     - ./ci/osx_fix_cellar.sh
-    - ./ci/osx_fix_rvm.sh
     - ./ci/github_checkout_branch.sh
 
 install:

--- a/ci/osx_fix_rvm.sh
+++ b/ci/osx_fix_rvm.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# https://github.com/travis-ci/travis-ci/issues/6307
-if [ "$TRAVIS_OS_NAME" = "osx" ]
-then
-    curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-    rvm get head
-fi


### PR DESCRIPTION
RVM causing problems on Travis again, this time it's fixed by removing `rvm get head` fix for an old-ish Travis issue. :disappointed: