### PR TITLE
Add Android Native filechooser and external SD card path to StoragePath

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Gyroscope                          X       X
 Humidity                           X
 IR Blaster                         X
 Light                              X
-Native file chooser                            X       X    X
+Native file chooser                X           X       X    X
 Notifications                      X           X       X    X
 Orientation                        X
 Proximity                          X

--- a/examples/filechooser/main.py
+++ b/examples/filechooser/main.py
@@ -1,0 +1,71 @@
+'''
+Example of an Android filechooser.
+'''
+
+from __future__ import unicode_literals
+from textwrap import dedent
+
+from plyer import filechooser
+
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.properties import ListProperty
+from kivy.uix.button import Button
+
+
+class FileChoose(Button):
+    '''
+    Button that triggers 'filechooser.open_file()' and processes
+    the data response from filechooser Activity.
+    '''
+
+    selection = ListProperty([])
+
+    def choose(self):
+        '''
+        Call plyer filechooser API to run a filechooser Activity.
+        '''
+        filechooser.open_file(on_selection=self.handle_selection)
+
+    def handle_selection(self, selection):
+        '''
+        Callback function for handling the selection response from Activity.
+        '''
+        self.selection = selection
+
+    def on_selection(self, *a, **k):
+        '''
+        Update TextInput.text after FileChoose.selection is changed
+        via FileChoose.handle_selection.
+        '''
+        App.get_running_app().root.ids.result.text = str(self.selection)
+
+
+class ChooserApp(App):
+    '''
+    Application class with root built in KV.
+    '''
+
+    def build(self):
+        return Builder.load_string(dedent('''
+            <FileChoose>:
+
+            BoxLayout:
+
+                BoxLayout:
+                    orientation: 'vertical'
+
+                    TextInput:
+                        id: result
+                        text: ''
+                        hint_text: 'selected path'
+
+                    FileChoose:
+                        size_hint_y: 0.1
+                        on_release: self.choose()
+                        text: 'Select a file'
+        '''))
+
+
+if __name__ == '__main__':
+    ChooserApp().run()

--- a/plyer/facades/filechooser.py
+++ b/plyer/facades/filechooser.py
@@ -32,9 +32,9 @@ Arguments:
 Important: these methods will return only after user interaction.
 Use threads or you will stop the mainloop if your app has one.
 
-Supported Platforms
--------------------
-Windows, OS X, Linux
+.. versionchanged:: 1.3.3
+    Added Android implementation for open_file()
+    Added ``on_selection`` kwarg for callback function
 '''
 
 

--- a/plyer/facades/filechooser.py
+++ b/plyer/facades/filechooser.py
@@ -27,6 +27,7 @@ Arguments:
         default.
     * **show_hidden** *(bool)*: Force showing hidden files (currently
         supported only on Windows)
+    * **on_selection** *(func)*: Callback for fetching the selection.
 
 Important: these methods will return only after user interaction.
 Use threads or you will stop the mainloop if your app has one.

--- a/plyer/facades/storagepath.py
+++ b/plyer/facades/storagepath.py
@@ -47,6 +47,14 @@ class StoragePath(object):
         '''
         return self._get_external_storage_dir()
 
+    def get_sdcard_dir(self):
+        '''
+        Get the path of external SD card.
+
+        .. versionadded:: 1.3.3
+        '''
+        return self._get_sdcard_dir()
+
     def get_root_dir(self):
         '''
         Get the path of root of the "system" partition holding the core OS.
@@ -100,6 +108,9 @@ class StoragePath(object):
         raise NotImplementedError()
 
     def _get_external_storage_dir(self):
+        raise NotImplementedError()
+
+    def _get_sdcard_dir(self):
         raise NotImplementedError()
 
     def _get_root_dir(self):

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -1,0 +1,367 @@
+'''
+Android file chooser
+--------------------
+
+Android runs ``Activity`` asynchronously via pausing our ``PythonActivity``
+and starting a new one in the foreground. This means
+``AndroidFileChooser._open_file()`` will always return the default value of
+``AndroidFileChooser.selection`` i.e. ``None``.
+
+After the ``Activity`` (for us it's the file chooser ``Intent``) is completed,
+Android moves it to the background (or destroys or whatever is implemented)
+and pushes ``PythonActivity`` to the foreground.
+
+We have a custom listener for ``android.app.Activity.onActivityResult()``
+via `android` package from `python-for-android` recipe,
+``AndroidFileChooser._on_activity_result()`` which is called independently of
+any our action (we may call anything from our application in Python and this
+handler will be called nevertheless on each ``android.app.Activity`` result
+in the system).
+
+In the handler we check if the ``request_code`` matches the code passed to the
+``Context.startActivityForResult()`` i.e. if the result from
+``android.app.Activity`` is indeed meant for our ``PythonActivity`` and then we
+proceed.
+
+Since the ``android.app.Activity.onActivityResult()`` is the only way for us
+to intercept the result and we have a handler bound via ``android`` package,
+we need to get the path/file/... selection to the user the same way.
+
+Threading + ``Thread.join()`` or ``time.sleep()`` or any other kind of waiting
+for the result is not an option because:
+
+1) ``android.app.Activity.onActivityResult()`` might remain unexecuted if
+the launched file chooser activity does not return the result (``Activity``
+dies/freezes/etc).
+
+2) Thread will be still waiting for the result e.g. an update of a value or
+to actually finish, however the result from the call of
+``AndroidFileChooser._open_file()`` will be returned nevertheless and anything
+using that result will use an incorrect one i.e. the default value of
+``AndroidFilechooser.selection`` (``None``).
+'''
+
+from __future__ import unicode_literals
+from os.path import join, basename
+from random import randint
+
+from android import activity, mActivity
+from jnius import autoclass, cast, JavaException
+from plyer.facades import FileChooser
+from plyer import storagepath
+
+
+String = autoclass('java.lang.String')
+Intent = autoclass('android.content.Intent')
+Activity = autoclass('android.app.Activity')
+DocumentsContract = autoclass('android.provider.DocumentsContract')
+ContentUris = autoclass('android.content.ContentUris')
+Uri = autoclass('android.net.Uri')
+Long = autoclass('java.lang.Long')
+IMedia = autoclass('android.provider.MediaStore$Images$Media')
+VMedia = autoclass('android.provider.MediaStore$Video$Media')
+AMedia = autoclass('android.provider.MediaStore$Audio$Media')
+
+
+class AndroidFileChooser(FileChooser):
+    '''
+    FileChooser implementation for Android using
+    the built-in file browser via Intent.
+    '''
+
+    # filechooser activity <-> result pair identification
+    select_code = None
+
+    # default selection value
+    selection = None
+
+    def __init__(self, *args, **kwargs):
+        super(AndroidFileChooser, self).__init__(*args, **kwargs)
+        self.select_code = randint(123456, 654321)
+        self.selection = None
+
+    @staticmethod
+    def _handle_selection(selection):
+        '''
+        Dummy placeholder for returning selection from
+        ``android.app.Activity.onActivityResult()``.
+        '''
+        return selection
+
+    def _open_file(self, **kwargs):
+        '''
+        Running Android Activity is non-blocking and the only call
+        that blocks is onActivityResult running in GUI thread
+        '''
+
+        # set up selection handler
+        # startActivityForResult is async
+        # onActivityResult is sync
+        self._handle_selection = kwargs.pop(
+            'on_selection', self._handle_selection
+        )
+
+        # create Intent for opening
+        file_intent = Intent(Intent.ACTION_GET_CONTENT)
+        file_intent.setType('*/*')
+        file_intent.addCategory(
+            Intent.CATEGORY_OPENABLE
+        )
+
+        # bind a function for a response from filechooser activity
+        activity.bind(on_activity_result=self._on_activity_result)
+
+        # start a new activity from PythonActivity
+        # which creates a filechooser via intent
+        mActivity.startActivityForResult(
+            Intent.createChooser(file_intent, cast(
+                'java.lang.CharSequence',
+                String("FileChooser")
+            )),
+            self.select_code
+        )
+
+    def _on_activity_result(self, request_code, result_code, data):
+        '''
+        Listener for ``android.app.Activity.onActivityResult()`` assigned
+        via ``android.activity.bind()``.
+        '''
+
+        # not our response
+        if request_code != self.select_code:
+            return
+
+        # bad response
+        if result_code != Activity.RESULT_OK:
+            print(
+                'Activity result failed',
+                result_code, data.getData().toString()
+            )
+            return
+
+        selection = self._resolve_uri(data.getData()) or []
+
+        # return value to object
+        self.selection = [selection]
+        # return value via callback
+        self._handle_selection([selection])
+
+    @staticmethod
+    def _handle_external_documents(uri):
+        '''
+        Selection from the system filechooser when using ``Phone``
+        or ``Internal storage`` or ``SD card`` option from menu.
+        '''
+
+        file_id = DocumentsContract.getDocumentId(uri)
+        file_type, file_name = file_id.split(':')
+
+        # internal SD card mostly mounted as a files storage in phone
+        internal = storagepath.get_external_storage_dir()
+
+        # external (removable) SD card i.e. microSD
+        external = storagepath.get_sdcard_dir()
+        external_base = basename(external)
+
+        # resolve sdcard path
+        sdcard = internal
+
+        # because external might have /storage/.../1 or other suffix
+        # and file_type might be only a part of the real folder in /storage
+        if file_type in external_base or external_base in file_type:
+            sdcard = external
+
+        path = join(sdcard, file_name)
+        return path
+
+    @staticmethod
+    def _handle_media_documents(uri):
+        '''
+        Selection from the system filechooser when using ``Images``
+        or ``Videos`` or ``Audio`` option from menu.
+        '''
+
+        file_id = DocumentsContract.getDocumentId(uri)
+        file_type, file_name = file_id.split(':')
+        selection = '_id=?'
+
+        if file_type == 'image':
+            uri = IMedia.EXTERNAL_CONTENT_URI
+        elif file_type == 'video':
+            uri = VMedia.EXTERNAL_CONTENT_URI
+        elif file_type == 'audio':
+            uri = AMedia.EXTERNAL_CONTENT_URI
+        return file_name, selection, uri
+
+    @staticmethod
+    def _handle_downloads_documents(uri):
+        '''
+        Selection from the system filechooser when using ``Downloads``
+        option from menu. Might not work all the time due to:
+
+        1) invalid URI:
+
+        jnius.jnius.JavaException:
+            JVM exception occurred: Unknown URI:
+            content://downloads/public_downloads/1034
+
+        2) missing URI / android permissions
+
+        jnius.jnius.JavaException:
+            JVM exception occurred:
+            Permission Denial: reading
+            com.android.providers.downloads.DownloadProvider uri
+            content://downloads/all_downloads/1034 from pid=2532, uid=10455
+            requires android.permission.ACCESS_ALL_DOWNLOADS,
+            or grantUriPermission()
+
+        Workaround:
+            Selecting path from ``Phone`` -> ``Download`` -> ``<file>``
+            (or ``Internal storage``) manually.
+        '''
+
+        # known locations, differ between machines
+        downloads = [
+            'content://downloads/public_downloads',
+            'content://downloads/my_downloads',
+
+            # all_downloads requires separate permission
+            # android.permission.ACCESS_ALL_DOWNLOADS
+            'content://downloads/all_downloads'
+        ]
+
+        file_id = DocumentsContract.getDocumentId(uri)
+        try_uris = [
+            ContentUris.withAppendedId(
+                Uri.parse(down), Long.valueOf(file_id)
+            )
+            for down in downloads
+        ]
+
+        # try all known Download folder uris
+        # and handle JavaExceptions due to different locations
+        # for content:// downloads or missing permission
+        path = None
+        for uri in try_uris:
+            try:
+                path = AndroidFileChooser._parse_content(
+                    uri=uri, projection=['_data'],
+                    selection=None,
+                    selection_args=None,
+                    sort_order=None
+                )
+
+            except JavaException:
+                import traceback
+                traceback.print_exc()
+
+            # we got a path, ignore the rest
+            if path:
+                break
+
+        # alternative approach to Downloads by joining
+        # all data items from Activity result
+        if not path:
+            path = AndroidFileChooser._parse_content(
+                uri=try_uris[1], projection=None,
+                selection=None,
+                selection_args=None,
+                sort_order=None,
+                index_all=True
+            )
+
+        return path
+
+    def _resolve_uri(self, uri):
+        '''
+        Resolve URI input from ``android.app.Activity.onActivityResult()``.
+        '''
+
+        uri_authority = uri.getAuthority()
+        uri_scheme = uri.getScheme().lower()
+
+        path = None
+        file_name = None
+        selection = None
+        downloads = None
+
+        # not a document URI, nothing to convert from
+        if not DocumentsContract.isDocumentUri(mActivity, uri):
+            return path
+
+        if uri_authority == 'com.android.externalstorage.documents':
+            return self._handle_external_documents(uri)
+
+        # in case a user selects a file from 'Downloads' section
+        # note: this won't be triggered if a user selects a path directly
+        #       e.g.: Phone -> Download -> <some file>
+        elif uri_authority == 'com.android.providers.downloads.documents':
+            path = downloads = self._handle_downloads_documents(uri)
+
+        elif uri_authority == 'com.android.providers.media.documents':
+            file_name, selection, uri = self._handle_media_documents(uri)
+
+        # parse content:// scheme to path
+        if uri_scheme == 'content' and not downloads:
+            path = self._parse_content(
+                uri=uri, projection=['_data'], selection=selection,
+                selection_args=[file_name], sort_order=None
+            )
+
+        # nothing to parse, file:// will return a proper path
+        elif uri_scheme == 'file':
+            path = uri.getPath()
+
+        return path
+
+    @staticmethod
+    def _parse_content(
+            uri, projection, selection, selection_args, sort_order,
+            index_all=False
+    ):
+        '''
+        Parser for ``content://`` URI returned by some Android resources.
+        '''
+
+        result = None
+        resolver = mActivity.getContentResolver()
+        read = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        write = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        persist = Intent.FLAG_GRANT_READ_URI_PERMISSION
+
+        # grant permission for our activity
+        mActivity.grantUriPermission(
+            mActivity.getPackageName(),
+            uri,
+            read | write | persist
+        )
+
+        if not index_all:
+            cursor = resolver.query(
+                uri, projection, selection,
+                selection_args, sort_order
+            )
+
+            idx = cursor.getColumnIndex(projection[0])
+            if idx != -1 and cursor.moveToFirst():
+                result = cursor.getString(idx)
+        else:
+            result = []
+            cursor = resolver.query(
+                uri, projection, selection,
+                selection_args, sort_order
+            )
+            while cursor.moveToNext():
+                for idx in range(cursor.getColumnCount()):
+                    result.append(cursor.getString(idx))
+            result = '/'.join(result)
+        return result
+
+    def _file_selection_dialog(self, **kwargs):
+        mode = kwargs.pop('mode', None)
+        if mode == 'open':
+            self._open_file(**kwargs)
+
+
+def instance():
+    return AndroidFileChooser()

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -39,6 +39,8 @@ to actually finish, however the result from the call of
 ``AndroidFileChooser._open_file()`` will be returned nevertheless and anything
 using that result will use an incorrect one i.e. the default value of
 ``AndroidFilechooser.selection`` (``None``).
+
+.. versionadded:: 1.3.3
 '''
 
 from __future__ import unicode_literals
@@ -67,6 +69,8 @@ class AndroidFileChooser(FileChooser):
     '''
     FileChooser implementation for Android using
     the built-in file browser via Intent.
+
+    .. versionadded:: 1.3.3
     '''
 
     # filechooser activity <-> result pair identification
@@ -85,6 +89,8 @@ class AndroidFileChooser(FileChooser):
         '''
         Dummy placeholder for returning selection from
         ``android.app.Activity.onActivityResult()``.
+
+        .. versionadded:: 1.3.3
         '''
         return selection
 
@@ -92,6 +98,8 @@ class AndroidFileChooser(FileChooser):
         '''
         Running Android Activity is non-blocking and the only call
         that blocks is onActivityResult running in GUI thread
+
+        .. versionadded:: 1.3.3
         '''
 
         # set up selection handler
@@ -125,6 +133,8 @@ class AndroidFileChooser(FileChooser):
         '''
         Listener for ``android.app.Activity.onActivityResult()`` assigned
         via ``android.activity.bind()``.
+
+        .. versionadded:: 1.3.3
         '''
 
         # not our response
@@ -151,6 +161,8 @@ class AndroidFileChooser(FileChooser):
         '''
         Selection from the system filechooser when using ``Phone``
         or ``Internal storage`` or ``SD card`` option from menu.
+
+        .. versionadded:: 1.3.3
         '''
 
         file_id = DocumentsContract.getDocumentId(uri)
@@ -179,6 +191,8 @@ class AndroidFileChooser(FileChooser):
         '''
         Selection from the system filechooser when using ``Images``
         or ``Videos`` or ``Audio`` option from menu.
+
+        .. versionadded:: 1.3.3
         '''
 
         file_id = DocumentsContract.getDocumentId(uri)
@@ -218,6 +232,8 @@ class AndroidFileChooser(FileChooser):
         Workaround:
             Selecting path from ``Phone`` -> ``Download`` -> ``<file>``
             (or ``Internal storage``) manually.
+
+        .. versionadded:: 1.3.3
         '''
 
         # known locations, differ between machines
@@ -275,6 +291,8 @@ class AndroidFileChooser(FileChooser):
     def _resolve_uri(self, uri):
         '''
         Resolve URI input from ``android.app.Activity.onActivityResult()``.
+
+        .. versionadded:: 1.3.3
         '''
 
         uri_authority = uri.getAuthority()
@@ -321,6 +339,8 @@ class AndroidFileChooser(FileChooser):
     ):
         '''
         Parser for ``content://`` URI returned by some Android resources.
+
+        .. versionadded:: 1.3.3
         '''
 
         result = None

--- a/plyer/platforms/android/storagepath.py
+++ b/plyer/platforms/android/storagepath.py
@@ -3,6 +3,8 @@ Android Storage Path
 --------------------
 '''
 
+from os import listdir, access, R_OK
+from os.path import join
 from plyer.facades import StoragePath
 from jnius import autoclass
 from android import mActivity
@@ -18,6 +20,23 @@ class AndroidStoragePath(StoragePath):
 
     def _get_external_storage_dir(self):
         return Environment.getExternalStorageDirectory().getAbsolutePath()
+
+    def _get_sdcard_dir(self):
+        '''
+        .. versionadded:: 1.3.3
+        '''
+        # folder in /storage/ that is readable
+        # and is not internal SD card
+        path = None
+        for folder in listdir('/storage'):
+            folder = join('/storage', folder)
+            if folder in self._get_external_storage_dir():
+                continue
+            if not access(folder, R_OK):
+                continue
+            path = folder
+            break
+        return path
 
     def _get_root_dir(self):
         return Environment.getRootDirectory().getAbsolutePath()

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -49,7 +49,7 @@ class SubprocessFileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):
+    def _handle_selection(selection):  # pylint: disable=method-hidden
         '''
         Dummy placeholder for returning selection from chooser.
         '''

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -39,10 +39,21 @@ class SubprocessFileChooser(object):
     icon = None
     show_hidden = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
+        self._handle_selection = kwargs.pop(
+            'on_selection', self._handle_selection
+        )
+
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
+
+    @staticmethod
+    def _handle_selection(selection):
+        '''
+        Dummy placeholder for returning selection from chooser.
+        '''
+        return selection
 
     _process = None
 
@@ -54,6 +65,7 @@ class SubprocessFileChooser(object):
                 if ret == self.successretcode:
                     out = self._process.communicate()[0].strip().decode('utf8')
                     self.selection = self._split_output(out)
+                    self._handle_selection(self.selection)
                     return self.selection
                 else:
                     return None

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -37,10 +37,21 @@ class MacFileChooser(object):
     show_hidden = False
     use_extensions = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
+        self._handle_selection = kwargs.pop(
+            'on_selection', self._handle_selection
+        )
+
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
+
+    @staticmethod
+    def _handle_selection(selection):
+        '''
+        Dummy placeholder for returning selection from chooser.
+        '''
+        return selection
 
     def run(self):
         panel = None
@@ -90,15 +101,19 @@ class MacFileChooser(object):
             panel.setDirectoryURL_(url)
 
         if panel.runModal():
+            selection = None
             if self.mode == "save" or not self.multiple:
-                return [panel.filename().UTF8String()]
+                selection = [panel.filename().UTF8String()]
             else:
-                return [i.UTF8String() for i in panel.filenames()]
+                selection = [i.UTF8String() for i in panel.filenames()]
+            self._handle_selection(selection)
+            return selection
         return None
 
 
 class MacOSXFileChooser(FileChooser):
-    '''FileChooser implementation for Windows, using win3all.
+    '''
+    FileChooser implementation for macOS using NSOpenPanel, NSSavePanel.
     '''
     def _file_selection_dialog(self, **kwargs):
         return MacFileChooser(**kwargs).run()

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -47,7 +47,7 @@ class MacFileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):
+    def _handle_selection(selection):  # pylint: disable=method-hidden
         '''
         Dummy placeholder for returning selection from chooser.
         '''

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -51,7 +51,7 @@ class Win32FileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):
+    def _handle_selection(selection):  # pylint: disable=method-hidden
         '''
         Dummy placeholder for returning selection from chooser.
         '''

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -41,10 +41,21 @@ class Win32FileChooser(object):
     icon = None
     show_hidden = False
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
+        self._handle_selection = kwargs.pop(
+            'on_selection', self._handle_selection
+        )
+
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
+
+    @staticmethod
+    def _handle_selection(selection):
+        '''
+        Dummy placeholder for returning selection from chooser.
+        '''
+        return selection
 
     def run(self):
         self.selection = []
@@ -119,6 +130,7 @@ class Win32FileChooser(object):
             # ALWAYS! let user know what happened
             import traceback
             traceback.print_exc()
+        self._handle_selection(self.selection)
         return self.selection
 
 


### PR DESCRIPTION
Adds external (micro) SD card path detection because otherwise the filechooser would return wrong path e.g.:

    /storage/emulated/0/file.txt
    /storage/extSdCard/file.txt

Android lacks an official API for fetching the path to the external SD card, however `/storage` folder contains both internal and external card. A user can read only those files by default. *Might* be an issue for rooted devices though if the folders are available for reading for root. This should not be an issue due to file ownership of a `system` user, however manufacturers can change anything.

Due to the Android's internals we need to "listen" for the response from user's filechooser `Activity`. Implementation details are properly described in the platform filechooser file. The same listener approach is added even to the all remaining platforms and preferably we might even switch to that because for other platforms it's a blocking call.

Switching to callbacks later would mean a user could just call a non-blocking `filechooser.open_file(on_selection=lambda path: func(path))` and the execution of the app would continue.