### PR TITLE
Enhance Android notifications with toast and big icons

### DIFF
--- a/examples/notification/main.py
+++ b/examples/notification/main.py
@@ -1,6 +1,4 @@
-from os.path import dirname
-from os.path import join
-from os.path import realpath
+from os.path import join, dirname, realpath
 
 import kivy
 kivy.require('1.8.0')
@@ -33,6 +31,8 @@ class NotificationDemo(BoxLayout):
             else:
                 kwargs['app_icon'] = join(dirname(realpath(__file__)),
                                           'plyer-icon.png')
+        elif mode == 'toast':
+            kwargs['toast'] = True
         notification.notify(**kwargs)
 
 

--- a/examples/notification/notificationdemo.kv
+++ b/examples/notification/notificationdemo.kv
@@ -1,6 +1,7 @@
 #:kivy 1.8.0
 <NotificationDemo>:
     orientation: 'vertical'
+    Widget:
     BoxLayout:
         orientation: 'horizontal'
         size_hint: 1, None
@@ -17,11 +18,15 @@
             text: 'New notification'
             size_hint: 1, None
     Button:
+        text: 'Toast Notification'
+        size_hint: 1, None
+        on_release: root.do_notify(mode='toast')
+    Button:
         text: 'Simple Notification'
         size_hint: 1, None
-        on_press: root.do_notify(mode='normal')
+        on_release: root.do_notify(mode='normal')
     Button:
         text: 'Fancy Notification'
         size_hint: 1, None
-        on_press:
-            root.do_notify(mode='fancy')
+        on_release: root.do_notify(mode='fancy')
+    Widget:

--- a/plyer/facades/notification.py
+++ b/plyer/facades/notification.py
@@ -23,12 +23,20 @@ Android toast notification::
 Android simple notification::
 
     >>> from plyer import notification
-    >>> notification.notify(message='hello')
+    >>> notification.notify(message='hello', toast=True)
+
+Notification with custom icon::
+
+    >>> from plyer import notification
+    >>> notification.notify(title='title', message='hello', app_icon=<path>)
 
 .. versionadded:: 1.0.0
 
 .. versionadded:: 1.3.3
    Add implementation of primitive Android popup-like notification (toast)
+
+.. versionchanged:: 1.3.3
+   Android implementation now supports custom icons for notifications.
 '''
 
 

--- a/plyer/facades/notification.py
+++ b/plyer/facades/notification.py
@@ -1,6 +1,6 @@
 '''
 Notification
-===========
+============
 
 The :class:`Notification` provides access to public methods to create
 notifications.
@@ -15,10 +15,20 @@ To send notification::
     >>> message = 'This is an example.'
     >>> notification.notify(title=title, message=message)
 
-Supported Platforms
--------------------
-Android, Windows, OS X, Linux
+Android toast notification::
 
+    >>> from plyer import notification
+    >>> notification.notify(message='hello', toast=True)
+
+Android simple notification::
+
+    >>> from plyer import notification
+    >>> notification.notify(message='hello')
+
+.. versionadded:: 1.0.0
+
+.. versionadded:: 1.3.3
+   Add implementation of primitive Android popup-like notification (toast)
 '''
 
 
@@ -29,7 +39,7 @@ class Notification(object):
     '''
 
     def notify(self, title='', message='', app_name='', app_icon='',
-               timeout=10, ticker=''):
+               timeout=10, ticker='', toast=False):
         # pylint: disable=too-many-arguments
         '''
         Send a notification.
@@ -41,20 +51,30 @@ class Notification(object):
         :param timeout: time to display the message for, defaults to 10
         :param ticker: text to display on status bar as the notification
                        arrives
+        :param toast: simple Android message instead of full notification
         :type title: str
         :type message: str
         :type app_name: str
         :type app_icon: str
         :type timeout: int
         :type ticker: str
+        :type toast: bool
 
         .. note::
            When called on Windows, ``app_icon`` has to be a path to
            a file in .ICO format.
+
+        .. versionadded:: 1.0.0
+
+        .. versionchanged:: 1.3.3
+           Add 'toast' keyword argument
         '''
 
-        self._notify(title=title, message=message, app_icon=app_icon,
-                     app_name=app_name, timeout=timeout, ticker=ticker)
+        self._notify(
+            title=title, message=message,
+            app_icon=app_icon, app_name=app_name,
+            timeout=timeout, ticker=ticker, toast=toast
+        )
 
     # private
 


### PR DESCRIPTION
On Android there's the `Toast` message which we used(?, I've never seen it on any device) in p4a when the lib loading fails. This is another case of a notification for the used, kind of like very simple `print(message)`, so it might be a good thing to add.

The displaying of the icons was not implemented properly (`setLargeIcon()` missing) and I've seen it previously in one of the implementations either on old IRC or somewhere with Android service examples, but couldn't find any file with that. So it'd be only good to allow a user to set own big icon while preserving a small icon of the source application.

![image](https://user-images.githubusercontent.com/8825439/50548101-4b79de00-0c47-11e9-9ac3-fe90f7057066.png)
Ref https://developer.android.com/guide/topics/ui/notifiers/notifications#Templates.