### PR TITLE
Implement WiFi for Linux with nmcli

### DIFF
--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -4,17 +4,13 @@
         - nmcli (Network Manager command line tool)
             It is found in most of the popular distros. Support for other
             managers is not provided yet.
-
-        - python-wifi module
-            `https://wifi.readthedocs.io/en/latest/`
-            `https://github.com/rockymeza/wifi`
-
 '''
 
 from plyer.facades import Wifi
 from subprocess import Popen, PIPE, call
 
 
+@deprecated
 class LinuxWifi(Wifi):
     '''
     .. versionadded:: 1.2.5

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -1,13 +1,273 @@
 '''
-    Note::
-        This facade depends on:
-        - nmcli (Network Manager command line tool)
-            It is found in most of the popular distros. Support for other
-            managers is not provided yet.
+.. note::
+   This facade depends on `nmcli` (Network Manager command line tool).
+   It's found in most of the popular GNU/Linux distributions. Support for other
+   backends is not provided yet.
 '''
 
-from plyer.facades import Wifi
 from subprocess import Popen, PIPE, call
+from plyer.facades import Wifi
+from plyer.utils import whereis_exe, deprecated
+
+
+class NMCLIWifi(Wifi):
+    '''
+    .. versionadded:: 1.3.3
+    '''
+
+    def __init__(self, *args, **kwargs):
+        '''
+        .. versionadded:: 1.3.3
+        '''
+
+        super(NMCLIWifi, self).__init__(*args, **kwargs)
+        self.names = {}
+
+    @property
+    def interfaces(self):
+        '''
+        Get all the available interfaces for WiFi.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self._is_enabled():
+            self._enable()
+
+        # fetch the devices
+        proc = Popen([
+            'nmcli', '--terse',
+            '--fields', 'DEVICE,TYPE',
+            'device'
+        ], stdout=PIPE)
+        lines = proc.communicate()[0].decode('utf-8').splitlines()
+
+        # filter devices by type
+        interfaces = []
+        for line in lines:
+            device, dtype = line.split(':')
+            if dtype != 'wifi':
+                continue
+            interfaces.append(device)
+
+        # return wifi interfaces
+        return interfaces
+
+    def _is_enabled(self):
+        '''
+        Return the status of WiFi device.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        output = Popen(
+            ["nmcli", "radio", "wifi"],
+            stdout=PIPE
+        ).communicate()[0].decode('utf-8')
+
+        if output.split()[0] == 'enabled':
+            return True
+        return False
+
+    def _is_connected(self, interface=None):
+        '''
+        Return whether a specified interface is connected to a WiFi network.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self._is_enabled():
+            self._enable()
+        if not interface:
+            interface = self.interfaces[0]
+
+        # fetch all devices
+        proc = Popen([
+            'nmcli', '--terse',
+            '--fields', 'DEVICE,TYPE,STATE',
+            'device'
+        ], stdout=PIPE)
+        lines = proc.communicate()[0].decode('utf-8').splitlines()
+
+        # filter by wifi type and interface
+        connected = False
+        for line in lines:
+            device, dtype, state = line.split(':')
+            if dtype != 'wifi':
+                continue
+
+            if device != interface:
+                continue
+
+            if state == 'connected':
+                connected = True
+
+        return connected
+
+    def _start_scanning(self, interface=None):
+        '''
+        Start scanning for available Wi-Fi networks
+        for the specified interface.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self._is_enabled():
+            self._enable()
+        if not interface:
+            interface = self.interfaces[0]
+
+        # force rescan for fresh data
+        call(['nmcli', 'device', 'wifi', 'rescan', 'ifname', interface])
+
+        # get properties
+        fields = [
+            'SSID', 'BSSID', 'MODE', 'CHAN', 'FREQ',
+            'BARS', 'RATE', 'SIGNAL', 'SECURITY'
+        ]
+
+        # fetch all networks for interface
+        output = Popen([
+            'nmcli', '--terse',
+            '--fields', ','.join(fields),
+            'device', 'wifi', 'list', 'ifname', interface
+        ], stdout=PIPE).communicate()[0].decode('utf-8')
+
+        # parse output
+        for line in output.splitlines():
+            line = line.replace('\\:', '$$')
+            row = {
+                field: value
+                for field, value in zip(fields, line.split(':'))
+            }
+
+            row['BSSID'] = row['BSSID'].replace('$$', ':')
+            self.names[row['SSID']] = row
+
+    def _get_network_info(self, name):
+        '''
+        Get all the network information by network's name (SSID).
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self.names:
+            self._start_scanning()
+
+        ret_list = {}
+        ret_list['ssid'] = self.names[name]['SSID']
+        ret_list['signal'] = self.names[name]['SIGNAL']
+
+        bars = len(self.names[name]['BARS'])
+        ret_list['quality'] = '{}/100'.format(bars / 5.0 * 100)
+        ret_list['frequency'] = self.names[name]['FREQ']
+        ret_list['bitrates'] = self.names[name]['RATE']
+
+        # wpa1, wpa2, wpa1 wpa2, wep, (none), perhaps something else
+        security = self.names[name]['SECURITY'].lower()
+        ret_list['encrypted'] = True
+        if 'wpa2' in security:
+            # wpa2, wpa2+wpa1
+            ret_list['encryption_type'] = 'wpa2'
+        elif 'wpa' in security:
+            ret_list['encryption_type'] = 'wpa'
+        elif 'wep' in security:
+            ret_list['encryption_type'] = 'wep'
+        elif 'none' in security:
+            ret_list['encrypted'] = False
+            ret_list['encryption_type'] = 'none'
+        else:
+            ret_list['encryption_type'] = security
+
+        ret_list['channel'] = int(self.names[name]['CHAN'])
+        ret_list['address'] = self.names[name]['BSSID']
+        ret_list['mode'] = self.names[name]['MODE']
+        return ret_list
+
+    def _get_available_wifi(self):
+        '''
+        Return the names of all found networks.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self.names:
+            self._start_scanning()
+        return list(self.names.keys())
+
+    def _connect(self, network, parameters, interface=None):
+        '''
+        Connect a specific interface to a WiFi network.
+
+        Expects 2 parameters:
+            - SSID of the network
+            - parameters: dict
+                - password: string or None
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        self._enable()
+        if not interface:
+            interface = self.interfaces[0]
+
+        password = parameters.get('password')
+        command = [
+            'nmcli', 'device', 'wifi', 'connect', network,
+            'ifname', interface
+        ]
+        if password:
+            command += ['password', password]
+        output = call(command)
+
+    def _disconnect(self, interface=None):
+        '''
+        Disconnect a specific interface from a WiFi network.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        if not self._is_enabled():
+            return
+
+        if not interface:
+            interface = self.interfaces[0]
+
+        if self._nmcli_version() >= (1, 2, 6):
+            call(['nmcli', 'device', 'disconnect', interface])
+        else:
+            call(['nmcli', 'nm', 'enable', 'false'])
+
+    def _enable(self):
+        '''
+        Turn WiFi device on.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        call(['nmcli', 'radio', 'wifi', 'on'])
+
+    def _disable(self):
+        '''
+        Turn WiFi device off.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        call(['nmcli', 'radio', 'wifi', 'off'])
+
+    def _nmcli_version(self):
+        '''
+        Get nmcli version to prevent executing deprecated commands.
+
+        .. versionadded:: 1.3.3
+           Tested with nmcli 1.2.6.
+        '''
+        version = Popen(['nmcli', '-v'], stdout=PIPE)
+        version = version.communicate()[0].decode('utf-8')
+        while version and not version[0].isdigit():
+            version = version[1:]
+        return tuple(map(int, (version.split('.'))))
 
 
 @deprecated
@@ -208,6 +468,9 @@ class LinuxWifi(Wifi):
 
 def instance():
     import sys
+
+    if whereis_exe('nmcli'):
+        return NMCLIWifi()
 
     try:
         import wifi  # pylint: disable=unused-variable,unused-import

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -45,10 +45,12 @@ class NMCLIWifi(Wifi):
         # filter devices by type
         interfaces = []
         for line in lines:
+            # bad escape from nmcli's side :<
+            line = line.replace('\\:', '$$')
             device, dtype = line.split(':')
             if dtype != 'wifi':
                 continue
-            interfaces.append(device)
+            interfaces.append(device.replace('$$', ':'))
 
         # return wifi interfaces
         return interfaces
@@ -92,7 +94,9 @@ class NMCLIWifi(Wifi):
         # filter by wifi type and interface
         connected = False
         for line in lines:
+            line = line.replace('\\:', '$$')
             device, dtype, state = line.split(':')
+            device = device.replace('$$', ':')
             if dtype != 'wifi':
                 continue
 
@@ -218,7 +222,7 @@ class NMCLIWifi(Wifi):
         ]
         if password:
             command += ['password', password]
-        output = call(command)
+        call(command)
 
     def _disconnect(self, interface=None):
         '''


### PR DESCRIPTION
Old `LinuxWifi` is marked as deprecated and will be removed after the next release. The current implementation fully relies on `nmcli` which is available on most popular distros. The next step is to add more low-level implementation that is purely based on kernel related stuff directly instead and `nmcli` as an alternative.

Closes #487.