### PR TITLE
fix the issue that tts.speak() crashes on android

### DIFF
--- a/plyer/platforms/android/tts.py
+++ b/plyer/platforms/android/tts.py
@@ -14,7 +14,7 @@ class AndroidTextToSpeech(TTS):
         tts.setLanguage(Locale.US)
 
         retries = 0  # First try rarely succeeds due to some timing issue
-        message = kwargs.get('message').encode('utf-8')  # always bytes
+        message = kwargs.get('message')
 
         # first try for while loop
         speak_status = tts.speak(


### PR DESCRIPTION
The current version of plyer/platforms/android/tts.py crashes when calling tts.speak(). This issue can be replicated using the text2speach example provided in plyer's examples folder. That throws out error like the below line:

`
07-28 13:01:49.767 32640 32676 I python  :  jnius.jnius.JavaException: No methods matching your arguments, available: ['(Ljava/lang/CharSequence;ILandroid/os/Bundle;Ljava/lang/String;)I', '(Ljava/lang/String;ILjava/util/HashMap;)I']
`

As the above error suggested, this commit updated adnroid/tts.py to pass message in string rather than in encoded bytes, as encoded bytes is not compatible with java.lang.String, which leads to crash of tts.speak(). According to my own tests, this fix works for both armeabi-v7a and arm64-v8a.

My environment:
- Ubuntu 18.04
- Buildozer 0.40.dev0
- Python 3.6.8