### PR TITLE
Add Windows applications storage path

### DIFF
--- a/plyer/platforms/win/storagepath.py
+++ b/plyer/platforms/win/storagepath.py
@@ -45,10 +45,8 @@ class WinStoragePath(StoragePath):
         return get_PATH(folderid)
 
     def _get_application_dir(self):
-        '''
-        To do.
-        '''
-        return "Method not implemented for current platform."
+        folderid = UUID('{905E63B6-C1BF-494E-B29C-65B732D3D21A}')
+        return get_PATH(folderid)
 
 
 def instance():

--- a/plyer/tests/test_storagepath.py
+++ b/plyer/tests/test_storagepath.py
@@ -43,6 +43,30 @@ class TestStoragePath(unittest.TestCase):
         self.assertIn(path_format, storagepath.get_pictures_dir())
         self.assertIn(path_format, storagepath.get_application_dir())
 
+    @PlatformTest('win')
+    def test_storagepath_macosx(self):
+        '''
+        Test macOS for plyer.storagepath.
+        '''
+        storagepath = platform_import(
+            platform='win',
+            module_name='storagepath'
+        )
+
+        self.assertIn('WinStoragePath', dir(storagepath))
+        storagepath = storagepath.instance()
+        self.assertIn('WinStoragePath', str(storagepath))
+
+        path_format = ':\\'
+
+        self.assertIn(path_format, storagepath.get_home_dir())
+        self.assertIn(path_format, storagepath.get_root_dir())
+        self.assertIn(path_format, storagepath.get_documents_dir())
+        self.assertIn(path_format, storagepath.get_downloads_dir())
+        self.assertIn(path_format, storagepath.get_videos_dir())
+        self.assertIn(path_format, storagepath.get_music_dir())
+        self.assertIn(path_format, storagepath.get_pictures_dir())
+        self.assertIn(path_format, storagepath.get_application_dir())
 
 if __name__ == '__main__':
     unittest.main()

--- a/plyer/tests/test_storagepath.py
+++ b/plyer/tests/test_storagepath.py
@@ -44,9 +44,9 @@ class TestStoragePath(unittest.TestCase):
         self.assertIn(path_format, storagepath.get_application_dir())
 
     @PlatformTest('win')
-    def test_storagepath_macosx(self):
+    def test_storagepath_windows(self):
         '''
-        Test macOS for plyer.storagepath.
+        Test win for plyer.storagepath.
         '''
         storagepath = platform_import(
             platform='win',

--- a/plyer/tests/test_storagepath.py
+++ b/plyer/tests/test_storagepath.py
@@ -68,5 +68,6 @@ class TestStoragePath(unittest.TestCase):
         self.assertIn(path_format, storagepath.get_pictures_dir())
         self.assertIn(path_format, storagepath.get_application_dir())
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added Windows applications storage path,
this will most likely point to C:\Program Files

Added Windows storage path tests.

Fixes issue #451 