### PR TITLE
Fix default audio file_path assignment error, file_path change for Py3

### DIFF
--- a/plyer/facades/audio.py
+++ b/plyer/facades/audio.py
@@ -47,6 +47,7 @@ Android
 
 from plyer.compat import string_types, text_type
 
+
 class Audio(object):
     '''
     Audio facade.

--- a/plyer/facades/audio.py
+++ b/plyer/facades/audio.py
@@ -45,6 +45,7 @@ Android
 
 '''
 
+from plyer.compat import string_types, text_type
 
 class Audio(object):
     '''
@@ -88,7 +89,7 @@ class Audio(object):
         '''
         Location of the recording.
         '''
-        assert isinstance(location, (basestring, unicode)), \
+        assert isinstance(location, (string_types, text_type)), \
             'Location must be string or unicode'
         self._file_path = location
 

--- a/plyer/platforms/macosx/audio.py
+++ b/plyer/platforms/macosx/audio.py
@@ -20,7 +20,7 @@ NSError = autoclass('NSError').alloc()
 class OSXAudio(Audio):
     def __init__(self, file_path=None):
         default_path = join(
-            OSXStoragePath().get_music_dir().encode('utf-8'),
+            OSXStoragePath().get_music_dir(),
             'audio.wav'
         )
         super(OSXAudio, self).__init__(file_path or default_path)


### PR DESCRIPTION
Fixes issue #515 and additionally fixes `TypeError: Can't mix strings and bytes in path components` with default audio `file_path` assignment.

Both fixes tested on Py2 and Py3.