### PR TITLE
Fix vibrator, which was not working on Android devices.

### DIFF
--- a/plyer/platforms/android/vibrator.py
+++ b/plyer/platforms/android/vibrator.py
@@ -1,38 +1,53 @@
-'''Implementation Vibrator for Android.'''
+"""Implementation Vibrator for Android."""
 
-from jnius import autoclass
+from jnius import autoclass, cast
 from plyer.facades import Vibrator
 from plyer.platforms.android import activity
 from plyer.platforms.android import SDK_INT
 
-Context = autoclass('android.content.Context')
-vibrator = activity.getSystemService(Context.VIBRATOR_SERVICE)
+Context = autoclass("android.content.Context")
+vibrator_service = activity.getSystemService(Context.VIBRATOR_SERVICE)
+vibrator = cast("android.os.Vibrator", vibrator_service)
+if SDK_INT >= 26:
+    VibrationEffect = autoclass("android.os.VibrationEffect")
 
 
 class AndroidVibrator(Vibrator):
-    '''Android Vibrator class.
+    """Android Vibrator class.
 
     Supported features:
         * vibrate for some period of time.
         * vibrate from given pattern.
         * cancel vibration.
         * check whether Vibrator exists.
-    '''
+    """
 
     def _vibrate(self, time=None, **kwargs):
         if vibrator:
-            vibrator.vibrate(int(1000 * time))
+            if SDK_INT >= 26:
+                vibrator.vibrate(
+                    VibrationEffect.createOneShot(
+                        int(1000 * time), VibrationEffect.DEFAULT_AMPLITUDE
+                    )
+                )
+            else:
+                vibrator.vibrate(int(1000 * time))
 
     def _pattern(self, pattern=None, repeat=None, **kwargs):
         pattern = [int(1000 * time) for time in pattern]
 
         if vibrator:
-            vibrator.vibrate(pattern, repeat)
+            if SDK_INT >= 26:
+                vibrator.vibrate(
+                    VibrationEffect.createWaveform(pattern, repeat)
+                )
+            else:
+                vibrator.vibrate(pattern, repeat)
 
     def _exists(self, **kwargs):
         if SDK_INT >= 11:
             return vibrator.hasVibrator()
-        elif activity.getSystemService(Context.VIBRATOR_SERVICE) is None:
+        elif vibrator_service is None:
             raise NotImplementedError()
         return True
 
@@ -41,8 +56,8 @@ class AndroidVibrator(Vibrator):
 
 
 def instance():
-    '''Returns Vibrator with android features.
+    """Returns Vibrator with android features.
 
     :return: instance of class AndroidVibrator
-    '''
+    """
     return AndroidVibrator()


### PR DESCRIPTION
Fixes #501 #509

In this PR I implemented a solution considering the deprecations applied since API 26 (check https://developer.android.com/reference/android/os/Vibrator). In order to make the vibration work again, I had to first use jnius.cast with "android.os.Vibrator" and VIBRATOR_SERVICE.

Since API 26, the VIbrationEffect class admits different types of vibrations, but I just implemented https://developer.android.com/reference/android/os/VibrationEffect.html#createOneShot(long,%20int) and https://developer.android.com/reference/android/os/VibrationEffect.html#createWaveform(long[],%20int), otherwise I could break plyer's VIbrator API.

This PR has been already tested. Anyway, I invite you to try it and post the results.