### PR TITLE
Fix for Android camera module

### DIFF
--- a/plyer/platforms/android/camera.py
+++ b/plyer/platforms/android/camera.py
@@ -6,7 +6,6 @@ from plyer.facades import Camera
 from plyer.platforms.android import activity
 
 Intent = autoclass('android.content.Intent')
-PythonActivity = autoclass('org.renpy.android.PythonActivity')
 MediaStore = autoclass('android.provider.MediaStore')
 Uri = autoclass('android.net.Uri')
 


### PR DESCRIPTION
Fixes #520

https://github.com/kivy/plyer/blob/0b7d8a08108ccb43d751d3fb6fb4a40a21b1ff6c/plyer/platforms/android/camera.py#L9
The plyer's Android camera module had an unused and deprecated PythonActivity. Removing it makes the module work again.