### PR TITLE
Handle absence of LinuxFileChooser backend

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -248,7 +248,7 @@ class LinuxFileChooser(FileChooser):
 
     def _file_selection_dialog(self, desktop_override=desktop, **kwargs):
         if not desktop_override:
-            desktop_override = desktop
+            desktop_override = self.desktop
         # This means we couldn't find any back-end
         if not desktop_override:
             raise OSError("No back-end available. Please install one.")


### PR DESCRIPTION
Currently this crashes with:
```
   File "/home/cheaterman/.local/lib/python3.7/site-packages/plyer/platforms/linux/filechooser.py", line 251, in _file_selection_dialog
     desktop_override = desktop
 NameError: name 'desktop' is not defined
```
when it should actually crash with:
```
   File "/home/cheaterman/.local/lib/python3.7/site-packages/plyer/platforms/linux/filechooser.py", line 254, in _file_selection_dialog
     raise OSError("No back-end available. Please install one.")
 OSError: No back-end available. Please install one.
```

Thanks :-)