### PR TITLE
Android FileChooser: Fix the increasing and repetitive calls to the "on_selection" callbacks

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -117,6 +117,9 @@ class AndroidFileChooser(FileChooser):
         )
 
         # bind a function for a response from filechooser activity
+        # but before that, lets unbind the function
+        # to avoid repetitive callbacks
+        activity.unbind(on_activity_result=self._on_activity_result)
         activity.bind(on_activity_result=self._on_activity_result)
 
         # start a new activity from PythonActivity


### PR DESCRIPTION
Please, refer to #530 for more information.
Fixes #530