### PR TITLE
Prevent crash when cancelling filechooser

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -142,7 +142,7 @@ class AndroidFileChooser(FileChooser):
             return
 
         if result_code != Activity.RESULT_OK:
-            # The action had been cancelled. To data to get
+            # The action had been cancelled.
             return
 
         selection = self._resolve_uri(data.getData()) or []

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -140,18 +140,26 @@ class AndroidFileChooser(FileChooser):
         # not our response, or nothing has been selected (selection cancelled)
         from kivy.logger import Logger
         Logger.info("Entering _on_activity_result. data = " + str(data))
-        if (request_code != self.select_code) or not data:
+        if (request_code != self.select_code):
             return
 
         # bad response
         if result_code != Activity.RESULT_OK:
-            print(
-                'Activity result failed',
-                result_code, data.getData().toString()
-            )
+            Logger.info("Activity.RESULT_OK not OK! Attempting getData")
+            try:
+                get_data = data.getData().toString()
+            except Exception as e:
+                get_data = str(e)
+
+            Logger.info("Activity result failed" + str(get_data))
             return
 
-        selection = self._resolve_uri(data.getData()) or []
+        try:
+            Logger.error("Trying getData()...")
+            selection = self._resolve_uri(data.getData()) or []
+            Logger.error("getData() success")
+        except Exception as e:
+            Logger.error("Error with getData(): " + str(e))
 
         # return value to object
         self.selection = [selection]

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -138,6 +138,7 @@ class AndroidFileChooser(FileChooser):
         '''
 
         # not our response, or nothing has been selected (selection cancelled)
+        from kivy.logger import Logger
         Logger.info("Entering _on_activity_result. data = " + str(data))
         if (request_code != self.select_code) or not data:
             return

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -138,6 +138,7 @@ class AndroidFileChooser(FileChooser):
         '''
 
         # not our response, or nothing has been selected (selection cancelled)
+        Logger.info("Entering _on_activity_result. data = " + str(data))
         if (request_code != self.select_code) or not data:
             return
 

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -137,29 +137,15 @@ class AndroidFileChooser(FileChooser):
         .. versionadded:: 1.4.0
         '''
 
-        # not our response, or nothing has been selected (selection cancelled)
-        from kivy.logger import Logger
-        Logger.info("Entering _on_activity_result. data = " + str(data))
-        if (request_code != self.select_code):
+        # not our response
+        if request_code != self.select_code:
             return
 
-        # bad response
         if result_code != Activity.RESULT_OK:
-            Logger.info("Activity.RESULT_OK not OK! Attempting getData")
-            try:
-                get_data = data.getData().toString()
-            except Exception as e:
-                get_data = str(e)
-
-            Logger.info("Activity result failed" + str(get_data))
+            # The action had been cancelled. To data to get
             return
 
-        try:
-            Logger.error("Trying getData()...")
-            selection = self._resolve_uri(data.getData()) or []
-            Logger.error("getData() success")
-        except Exception as e:
-            Logger.error("Error with getData(): " + str(e))
+        selection = self._resolve_uri(data.getData()) or []
 
         # return value to object
         self.selection = [selection]

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -137,8 +137,8 @@ class AndroidFileChooser(FileChooser):
         .. versionadded:: 1.4.0
         '''
 
-        # not our response
-        if request_code != self.select_code:
+        # not our response, or nothing has been selected (selection cancelled)
+        if (request_code != self.select_code) or not data:
             return
 
         # bad response


### PR DESCRIPTION
Closes #534

This issue can be easily verified by running this example.

    https://github.com/kivy/plyer/tree/master/examples/filechooser

All is well when a file is selected, but pressing the back button to cancel selection crashes it (with the error log shown in #534) as the "getData()" method tries to fetch non-existent data.