### PR TITLE
fix-gps

### DIFF
--- a/plyer/platforms/android/__init__.py
+++ b/plyer/platforms/android/__init__.py
@@ -3,6 +3,7 @@ from jnius import autoclass
 
 ANDROID_VERSION = autoclass('android.os.Build$VERSION')
 SDK_INT = ANDROID_VERSION.SDK_INT
+ActivityCompat = autoclass('androidx.core.app.ActivityCompat')
 
 try:
     from android import config

--- a/plyer/platforms/android/__init__.py
+++ b/plyer/platforms/android/__init__.py
@@ -17,3 +17,7 @@ if 'PYTHON_SERVICE_ARGUMENT' in environ:
 else:
     PythonActivity = autoclass(ns + '.PythonActivity')
     activity = PythonActivity.mActivity
+
+# AndroidManifest.xml abstraction
+# Ex. ["android.permission.INTERNET",]
+Manifest = list()

--- a/plyer/platforms/android/gps.py
+++ b/plyer/platforms/android/gps.py
@@ -4,7 +4,7 @@ Android GPS
 '''
 
 from plyer.facades import GPS
-from plyer.platforms.android import activity
+from plyer.platforms.android import SDK_INT, Manifest, activity, ActivityCompat
 from jnius import autoclass, java_method, PythonJavaClass
 
 Looper = autoclass('android.os.Looper')

--- a/plyer/platforms/android/gps.py
+++ b/plyer/platforms/android/gps.py
@@ -19,6 +19,14 @@ class _LocationListener(PythonJavaClass):
         self.root = root
         super(_LocationListener, self).__init__()
 
+        # programmatically request permission for GPS (as required by the API.)
+        if SDK_INT >= 23:
+            Manifest.extend([
+                'android.permission.ACCESS_FINE_LOCATION',
+                'android.permission.ACCESS_COARSE_LOCATION'
+            ])
+            ActivityCompat.requestPermissions(activity, Manifest, 1000)
+
     @java_method('(Landroid/location/Location;)V')
     def onLocationChanged(self, location):
         self.root.on_location(


### PR DESCRIPTION
Fix for programmatically requesting permissions (required for Android API 23 and greater,) particularly for GPS on Android. TL;DR: this makes GPS work again, on Android!

In order for this fix to actually work some other parts of the Kivy framework also require minor patches. As they are specified in buildozer.spec the following values must be set:

android.api = 29
android.gradle_dependencies = 'com.google.android.gms:play-services-location:17.0.0'

It would be nice it could be possible to parse the permissions from buildozer.spec during build, and package it with a text file in the APK, or a simple AndroidManifest.xml parser that plyer could read on initialization. That way, the Manifest list in __init__ could properly be populated with all of the necessary permissions in one place, in case additional endpoints require this patch.