### PR TITLE
Fixing DOCUMENTS key and raised exception

### DIFF
--- a/plyer/platforms/linux/storagepath.py
+++ b/plyer/platforms/linux/storagepath.py
@@ -30,7 +30,7 @@ class LinuxStoragePath(StoragePath):
                          if v.startswith("XDG_" + name)][0]
                 return lines[index].split('"')[1]
         except (KeyError, FileNotFoundError):
-            return PATHS[name]
+            return self._get_home_dir() + PATHS[name]
         except Exception as e:
             raise e
 

--- a/plyer/platforms/linux/storagepath.py
+++ b/plyer/platforms/linux/storagepath.py
@@ -29,7 +29,7 @@ class LinuxStoragePath(StoragePath):
                 index = [i for i, v in enumerate(lines)
                          if v.startswith("XDG_" + name)][0]
                 return lines[index].split('"')[1]
-        except (KeyError, FileNotFoundError):
+        except KeyError:
             return self._get_home_dir() + PATHS[name]
         except Exception as e:
             raise e

--- a/plyer/platforms/linux/storagepath.py
+++ b/plyer/platforms/linux/storagepath.py
@@ -29,7 +29,7 @@ class LinuxStoragePath(StoragePath):
                 index = [i for i, v in enumerate(lines)
                          if v.startswith("XDG_" + name)][0]
                 return lines[index].split('"')[1]
-        except KeyError:
+        except (KeyError, FileNotFoundError):
             return PATHS[name]
         except Exception as e:
             raise e
@@ -44,7 +44,7 @@ class LinuxStoragePath(StoragePath):
         return "/"
 
     def _get_documents_dir(self):
-        directory = self._get_from_user_dirs("DOCUMENT")
+        directory = self._get_from_user_dirs("DOCUMENTS")
         return directory.replace("$HOME", self._get_home_dir())
 
     def _get_downloads_dir(self):


### PR DESCRIPTION
Hello, I was trying to use plyer and I found that I couldn't access document folder on my Linux, this was because of two reasons:

```python
 with open(self._get_home_dir() + USER_DIRS, "r") as f:
```

raises a `FileNotFoundError` if `~/.config/user-dirs.dirs` doesn't exist (but the current code is only handling the case of `KeyError`, which happens if the key does not exist in user-dirs).

Also line 47 was sending `DOCUMENT` which worked for the `user-dirs.dirs` because it started with the same characters, but failed when trying to access `PATHS` because the key is `DOCUMENTS` 