### PR TITLE
Fix crash in Android Notification (SDK_INT >= 26)

### DIFF
--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -26,6 +26,7 @@ from plyer.platforms.android import activity, SDK_INT
 AndroidString = autoclass('java.lang.String')
 Context = autoclass('android.content.Context')
 NotificationBuilder = autoclass('android.app.Notification$Builder')
+NotificationManager = autoclass('android.app.NotificationManager')
 Drawable = autoclass("{}.R$drawable".format(activity.getPackageName()))
 PendingIntent = autoclass('android.app.PendingIntent')
 Intent = autoclass('android.content.Intent')
@@ -47,9 +48,9 @@ class AndroidNotification(Notification):
 
     def _get_notification_service(self):
         if not self._ns:
-            self._ns = activity.getSystemService(
+            self._ns = cast(NotificationManager, activity.getSystemService(
                 Context.NOTIFICATION_SERVICE
-            )
+            ))
         return self._ns
 
     def _build_notification_channel(self, name):
@@ -65,13 +66,12 @@ class AndroidNotification(Notification):
         if SDK_INT < 26:
             return
 
-        manager = autoclass('android.app.NotificationManager')
         channel = autoclass('android.app.NotificationChannel')
 
         app_channel = channel(
-            self._channel_id, name, manager.IMPORTANCE_DEFAULT
+            self._channel_id, name, NotificationManager.IMPORTANCE_DEFAULT
         )
-        activity.getSystemService(manager).createNotificationChannel(
+        self._get_notification_service().createNotificationChannel(
             app_channel
         )
         return app_channel


### PR DESCRIPTION
This pull request fixes the following error appearing in SDK_INT >= 26:

```
JNI DETECTED ERROR IN APPLICATION: bad arguments passed to
java.lang.Object android.app.Activity.getSystemService(java.lang.String)
```

It seems that the error is happening because there is a bug in pyjnius
where `getSystemService(java.lang.Class)` is not recognized. So, instead
of using `getSystemService(manager)`, `_get_notification_service` is
used, which returns `(NotificationManager)
getSystemService(Context.NOTIFICATION_SERVICE)`.

Fixes #504,  Fixes #533 