### PR TITLE
Remove unused linters

### DIFF
--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -19,7 +19,6 @@ __version__ = '2.0.0.dev0'
 from plyer import facades
 from plyer.utils import Proxy
 
-# pylint: disable=invalid-name
 #: Accelerometer proxy to :class:`plyer.facades.Accelerometer`
 accelerometer = Proxy('accelerometer', facades.Accelerometer)
 

--- a/plyer/facades/email.py
+++ b/plyer/facades/email.py
@@ -31,7 +31,6 @@ Android, iOS, Windows, OS X, Linux
 
 
 class Email(object):
-    # pylint: disable=too-few-public-methods
     '''
     Email facade.
     '''

--- a/plyer/facades/notification.py
+++ b/plyer/facades/notification.py
@@ -41,14 +41,12 @@ Notification with custom icon::
 
 
 class Notification(object):
-    # pylint: disable=too-few-public-methods
     '''
     Notification facade.
     '''
 
     def notify(self, title='', message='', app_name='', app_icon='',
                timeout=10, ticker='', toast=False):
-        # pylint: disable=too-many-arguments
         '''
         Send a notification.
 

--- a/plyer/facades/uniqueid.py
+++ b/plyer/facades/uniqueid.py
@@ -35,7 +35,7 @@ class UniqueID(object):
     '''
 
     @property
-    def id(self):  # pylint: disable=invalid-name
+    def id(self):
         '''
         Property that returns the unique id of the platform.
         '''

--- a/plyer/platforms/android/battery.py
+++ b/plyer/platforms/android/battery.py
@@ -2,7 +2,7 @@
 Module of Android API for plyer.battery.
 '''
 
-from jnius import autoclass, cast  # pylint: disable=no-name-in-module
+from jnius import autoclass, cast
 from plyer.platforms.android import activity
 from plyer.facades import Battery
 

--- a/plyer/platforms/android/email.py
+++ b/plyer/platforms/android/email.py
@@ -2,7 +2,7 @@
 Module of Android API for plyer.email.
 '''
 
-from jnius import autoclass, cast  # pylint: disable=no-name-in-module
+from jnius import autoclass, cast
 from plyer.facades import Email
 from plyer.platforms.android import activity
 
@@ -11,7 +11,6 @@ AndroidString = autoclass('java.lang.String')
 
 
 class AndroidEmail(Email):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Android email API.
     '''

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -88,7 +88,7 @@ class AndroidFileChooser(FileChooser):
         activity.bind(on_activity_result=self._on_activity_result)
 
     @staticmethod
-    def _handle_selection(selection):  # pylint: disable=method-hidden
+    def _handle_selection(selection):
         '''
         Dummy placeholder for returning selection from
         ``android.app.Activity.onActivityResult()``.
@@ -338,7 +338,7 @@ class AndroidFileChooser(FileChooser):
         return path
 
     @staticmethod
-    def _parse_content(  # pylint: disable=too-many-arguments
+    def _parse_content(
             uri, projection, selection, selection_args, sort_order,
             index_all=False
     ):

--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -35,7 +35,6 @@ BitmapFactory = autoclass('android.graphics.BitmapFactory')
 
 
 class AndroidNotification(Notification):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Android notification API.
 

--- a/plyer/platforms/ios/battery.py
+++ b/plyer/platforms/ios/battery.py
@@ -2,8 +2,8 @@
 Module of iOS API for plyer.battery.
 '''
 
-from pyobjus import autoclass  # pylint: disable=import-error
-from pyobjus.dylib_manager import load_framework  # pylint:disable=import-error
+from pyobjus import autoclass
+from pyobjus.dylib_manager import load_framework
 from plyer.facades import Battery
 
 load_framework('/System/Library/Frameworks/UIKit.framework')

--- a/plyer/platforms/ios/email.py
+++ b/plyer/platforms/ios/email.py
@@ -8,8 +8,8 @@ except ImportError:
     from urllib import quote
 
 from plyer.facades import Email
-from pyobjus import autoclass, objc_str  # pylint: disable=import-error
-from pyobjus.dylib_manager import load_framework  # pylint:disable=import-error
+from pyobjus import autoclass, objc_str
+from pyobjus.dylib_manager import load_framework
 
 load_framework('/System/Library/Frameworks/UIKit.framework')
 
@@ -19,7 +19,6 @@ UIApplication = autoclass('UIApplication')
 
 
 class IOSEmail(Email):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of iOS battery API.
     '''

--- a/plyer/platforms/ios/uniqueid.py
+++ b/plyer/platforms/ios/uniqueid.py
@@ -2,8 +2,8 @@
 Module of iOS API for plyer.uniqueid.
 '''
 
-from pyobjus import autoclass  # pylint: disable=import-error
-from pyobjus.dylib_manager import load_framework  # pylint:disable=import-error
+from pyobjus import autoclass
+from pyobjus.dylib_manager import load_framework
 from plyer.facades import UniqueID
 
 load_framework('/System/Library/Frameworks/UIKit.framework')

--- a/plyer/platforms/linux/email.py
+++ b/plyer/platforms/linux/email.py
@@ -12,7 +12,6 @@ from plyer.utils import whereis_exe
 
 
 class LinuxEmail(Email):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Linux email API.
     '''

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -49,7 +49,7 @@ class SubprocessFileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):  # pylint: disable=method-hidden
+    def _handle_selection(selection):
         '''
         Dummy placeholder for returning selection from chooser.
         '''

--- a/plyer/platforms/linux/notification.py
+++ b/plyer/platforms/linux/notification.py
@@ -9,7 +9,6 @@ from plyer.utils import whereis_exe
 
 
 class NotifySendNotification(Notification):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Linux notification API
     using notify-send binary.
@@ -21,14 +20,12 @@ class NotifySendNotification(Notification):
 
 
 class NotifyDbus(Notification):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Linux notification API
     using dbus library and dbus-python wrapper.
     '''
 
     def _notify(self, **kwargs):
-        # pylint: disable=too-many-locals
         summary = kwargs.get('title', "title")
         body = kwargs.get('message', "body")
         app_name = kwargs.get('app_name', '')
@@ -42,7 +39,7 @@ class NotifyDbus(Notification):
         _object_path = '/org/freedesktop/Notifications'
         _interface_name = _bus_name
 
-        import dbus  # pylint: disable=import-error
+        import dbus
         session_bus = dbus.SessionBus()
         obj = session_bus.get_object(_bus_name, _object_path)
         interface = dbus.Interface(obj, _interface_name)

--- a/plyer/platforms/macosx/email.py
+++ b/plyer/platforms/macosx/email.py
@@ -14,7 +14,6 @@ from plyer.utils import whereis_exe
 
 
 class MacOSXEmail(Email):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of MacOS email API.
     '''

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -47,7 +47,7 @@ class MacFileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):  # pylint: disable=method-hidden
+    def _handle_selection(selection):
         '''
         Dummy placeholder for returning selection from chooser.
         '''

--- a/plyer/platforms/macosx/notification.py
+++ b/plyer/platforms/macosx/notification.py
@@ -7,7 +7,7 @@ from plyer.facades import Notification
 from pyobjus import (
     autoclass, protocol, objc_str, ObjcBOOL
 )
-from pyobjus.dylib_manager import (  # pylint: disable=import-error
+from pyobjus.dylib_manager import (
     load_framework, INCLUDE
 )
 
@@ -41,8 +41,6 @@ class OSXNotification(Notification):
     @protocol('NSUserNotificationCenterDelegate')
     def userNotificationCenter_shouldPresentNotification_(
             self, center, notification):
-        # pylint: disable=invalid-name,missing-docstring
-        # pylint: disable=unused-argument,no-self-use
         return ObjcBOOL(True)
 
 

--- a/plyer/platforms/win/cpu.py
+++ b/plyer/platforms/win/cpu.py
@@ -19,7 +19,6 @@ ERROR_INSUFFICIENT_BUFFER = 0x0000007A
 
 
 class CacheType(object):
-    # pylint: disable=too-few-public-methods
     '''
     Win API PROCESSOR_CACHE_TYPE enum.
     '''
@@ -31,7 +30,6 @@ class CacheType(object):
 
 
 class RelationshipType(object):
-    # pylint: disable=too-few-public-methods
     '''
     Win API LOGICAL_PROCESSOR_RELATIONSHIP enum.
     '''
@@ -45,7 +43,6 @@ class RelationshipType(object):
 
 
 class CacheDescriptor(Structure):
-    # pylint: disable=too-few-public-methods
     '''
     Win API CACHE_DESCRIPTOR struct.
     '''
@@ -60,7 +57,6 @@ class CacheDescriptor(Structure):
 
 
 class ProcessorCore(Structure):
-    # pylint: disable=too-few-public-methods
     '''
     Win API ProcessorCore struct.
     '''
@@ -69,7 +65,6 @@ class ProcessorCore(Structure):
 
 
 class NumaNode(Structure):
-    # pylint: disable=too-few-public-methods
     '''
     Win API NumaNode struct.
     '''
@@ -78,7 +73,6 @@ class NumaNode(Structure):
 
 
 class SystemLPIUnion(Union):
-    # pylint: disable=too-few-public-methods
     '''
     Win API SYSTEM_LOGICAL_PROCESSOR_INFORMATION union without name.
     '''
@@ -92,7 +86,6 @@ class SystemLPIUnion(Union):
 
 
 class SystemLPI(Structure):
-    # pylint: disable=too-few-public-methods
     '''
     Win API SYSTEM_LOGICAL_PROCESSOR_INFORMATION struct.
     '''

--- a/plyer/platforms/win/email.py
+++ b/plyer/platforms/win/email.py
@@ -11,7 +11,6 @@ from plyer.facades import Email
 
 
 class WindowsEmail(Email):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Windows email API.
     '''
@@ -35,8 +34,8 @@ class WindowsEmail(Email):
 
         # WE + startfile are available only on Windows
         try:
-            os.startfile(uri)  # pylint: disable=no-member
-        except WindowsError:  # pylint: disable=undefined-variable
+            os.startfile(uri)
+        except WindowsError:
             print("Warning: unable to find a program able to send emails.")
 
 

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -52,7 +52,7 @@ class Win32FileChooser(object):
             setattr(self, i, kwargs[i])
 
     @staticmethod
-    def _handle_selection(selection):  # pylint: disable=method-hidden
+    def _handle_selection(selection):
         '''
         Dummy placeholder for returning selection from chooser.
         '''
@@ -126,7 +126,7 @@ class Win32FileChooser(object):
                 BIF_EDITBOX = shellcon.BIF_EDITBOX
                 BIF_NEWDIALOGSTYLE = 0x00000040
                 # From http://goo.gl/UDqCqo
-                pidl, name, images = browse(  # pylint: disable=unused-variable
+                pidl, name, images = browse(
                     win32gui.GetDesktopWindow(),
                     None,
                     self.title if self.title else "Pick a folder...",

--- a/plyer/platforms/win/libs/balloontip.py
+++ b/plyer/platforms/win/libs/balloontip.py
@@ -81,7 +81,6 @@ class WindowsBalloonTip(object):
 
     def __init__(self, title, message, app_name, app_icon='',
                  timeout=10, **kwargs):
-        # pylint: disable=unused-argument,too-many-arguments
         '''
         The app_icon parameter, if given, is an .ICO file.
         '''

--- a/plyer/platforms/win/libs/batterystatus.py
+++ b/plyer/platforms/win/libs/batterystatus.py
@@ -18,7 +18,6 @@ def battery_status():
     if not win_api_defs.GetSystemPowerStatus(ctypes.pointer(status)):
         raise Exception('Could not get system power status.')
 
-    # pylint: disable=protected-access
     return dict(
         (field, getattr(status, field))
         for field, _ in status._fields_

--- a/plyer/platforms/win/libs/wifi_defs.py
+++ b/plyer/platforms/win/libs/wifi_defs.py
@@ -291,7 +291,7 @@ def _connect(network, parameters):
     '''
     Attempts to connect to a specific network.
     '''
-    global _dict  # pylint: disable=global-statement
+    global _dict
     wireless_interface = _dict[network]
 
     wcp = WLAN_CONNECTION_PARAMETERS()
@@ -403,8 +403,8 @@ def _start_scanning():
     '''
     Private method for scanning and returns the available devices.
     '''
-    global available  # pylint: disable=global-statement
-    global wireless_interfaces  # pylint: disable=global-statement
+    global available
+    global wireless_interfaces
     NegotiatedVersion = DWORD()
     ClientHandle = HANDLE()
 
@@ -481,8 +481,8 @@ def _get_network_info(name):
     '''
     returns the list of the network selected in a dict.
     '''
-    global available  # pylint: disable=global-statement
-    global _dict  # pylint: disable=global-statement
+    global available
+    global _dict
 
     net = _dict[name]
     dot11BssType = net.dot11BssType
@@ -506,8 +506,8 @@ def _make_dict():
     '''
     Prepares a dict so it could store network information.
     '''
-    global available  # pylint: disable=global-statement
-    global _dict  # pylint: disable=global-statement
+    global available
+    global _dict
     _dict = {}
     for network in available:
         # if bytes, dict['name'] throws an error on py3 if not b'name'
@@ -521,7 +521,7 @@ def _get_available_wifi():
     '''
     returns the available wifi networks.
     '''
-    global _dict  # pylint: disable=global-statement
+    global _dict
     return _dict
 
 

--- a/plyer/platforms/win/notification.py
+++ b/plyer/platforms/win/notification.py
@@ -9,7 +9,6 @@ from plyer.platforms.win.libs.balloontip import balloon_tip
 
 
 class WindowsNotification(Notification):
-    # pylint: disable=too-few-public-methods
     '''
     Implementation of Windows notification/balloon API.
     '''

--- a/plyer/platforms/win/uniqueid.py
+++ b/plyer/platforms/win/uniqueid.py
@@ -3,10 +3,10 @@ Module of Windows API for plyer.uniqueid.
 '''
 
 try:
-    import _winreg as regedit  # pylint: disable=import-error
+    import _winreg as regedit
 except ImportError:
     try:
-        import winreg as regedit  # pylint: disable=import-error
+        import winreg as regedit
     except ImportError:
         raise NotImplementedError()
 

--- a/plyer/tests/common.py
+++ b/plyer/tests/common.py
@@ -15,7 +15,6 @@ from plyer.utils import platform as plyer_platform
 
 
 class PlatformTest(object):
-    # pylint: disable=too-few-public-methods
     '''
     Class for the @PlatformTest decorator to prevent running tests
     calling platform dependent API on different platforms.
@@ -36,7 +35,6 @@ class PlatformTest(object):
 
     @staticmethod
     def eat(*args, **kwargs):
-        # pylint: disable=unused-argument
         '''
         Simply eat all positional and keyword arguments
         and return None as an empty function.

--- a/plyer/tests/test_battery.py
+++ b/plyer/tests/test_battery.py
@@ -324,7 +324,6 @@ class TestBattery(unittest.TestCase):
         '''
 
         def false(*args, **kwargs):
-            # pylint: disable=unused-argument
             return False
 
         sysclass = MockedKernelSysclass()

--- a/plyer/tests/test_email.py
+++ b/plyer/tests/test_email.py
@@ -38,7 +38,7 @@ class TestEmail(unittest.TestCase):
                     text='text'
                 )
             startfile.assert_called_once_with(test_mailto)
-        except WindowsError:  # pylint: disable=undefined-variable
+        except WindowsError:
             # if WE is raised, email client isn't found,
             # but the platform code works correctly
             print('Mail client not found!')

--- a/plyer/tests/test_facade.py
+++ b/plyer/tests/test_facade.py
@@ -62,16 +62,13 @@ class DummyJnius(object):
     Mocked PyJNIus module.
     '''
 
-    # pylint: disable=too-few-public-methods
     def __init__(self, *args, **kwargs):
-        # pylint: disable=unused-argument
         class JavaClass:
             '''
             Mocked PyJNIus JavaClass object.
             '''
 
             def __init__(self):
-                # pylint: disable=invalid-name
                 self.ANDROID_VERSION = None
                 self.SDK_INT = 1
                 self.mActivity = None
@@ -138,7 +135,6 @@ class TestFacade(unittest.TestCase):
 
         # no 'unknown' platform (folder), fallback to facade
         class MockedProxy(plyer.utils.Proxy):
-            # pylint: disable=too-few-public-methods
             '''
             Partially mocked Proxy class, so that we pull the error
             from traceback.print_exc to the test and check the calls.
@@ -151,7 +147,6 @@ class TestFacade(unittest.TestCase):
             expected_asserts = [True, False, False]
 
             def _ensure_obj(inst):
-                # pylint: disable=no-self-argument
                 # called once, prints to stderr
 
                 # mock stderr because traceback.print_exc uses it
@@ -182,7 +177,6 @@ class TestFacade(unittest.TestCase):
         facade = Mock()
         dummy = proxy_cls('dummy', facade)
 
-        # pylint: disable=protected-access
         self.assertEqual(dummy._mock_new_parent, facade)
         plyer.utils.platform = _original
 

--- a/plyer/tests/test_notification.py
+++ b/plyer/tests/test_notification.py
@@ -93,7 +93,6 @@ class TestNotification(unittest.TestCase):
         clsnames = []
 
         def fetch_class(hwnd, *args):
-            # pylint: disable=unused-argument
             '''
             EnumWindowsProc callback for EnumWindows.
             '''

--- a/plyer/tests/test_uniqueid.py
+++ b/plyer/tests/test_uniqueid.py
@@ -30,12 +30,12 @@ class TestUniqueID(unittest.TestCase):
         Test Windows API for plyer.uniqueid.
         '''
         try:
-            from winreg import (  # pylint: disable=import-error
+            from winreg import (
                 HKEY_LOCAL_MACHINE as HKLM,
                 KEY_READ as READ, KEY_WOW64_64KEY as VIEW
             )
         except ImportError:
-            from _winreg import (  # pylint: disable=import-error
+            from _winreg import (
                 HKEY_LOCAL_MACHINE as HKLM,
                 KEY_READ as READ, KEY_WOW64_64KEY as VIEW
             )

--- a/plyer/tests/test_utils.py
+++ b/plyer/tests/test_utils.py
@@ -138,11 +138,10 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):  # pylint: disable=useless-object-inheritance
+        class Class(object):
             '''
             Dummy class with deprecated method method.
             '''
-            # pylint: disable=too-few-public-methods
             def __init__(self, *args, **kwargs):
                 self.args = args
                 self.kwargs = kwargs
@@ -185,11 +184,10 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):  # pylint: disable=useless-object-inheritance
+        class Class(object):
             '''
             Dummy class with deprecated static method.
             '''
-            # pylint: disable=too-few-public-methods
             args = None
             kwargs = None
 
@@ -234,11 +232,10 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):  # pylint: disable=useless-object-inheritance
+        class Class(object):
             '''
             Dummy class with deprecated static method.
             '''
-            # pylint: disable=too-few-public-methods
             args = None
             kwargs = None
 
@@ -287,11 +284,10 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):  # pylint: disable=useless-object-inheritance
+        class Class(object):
             '''
             Dummy class with deprecated class method.
             '''
-            # pylint: disable=too-few-public-methods
             args = None
             kwargs = None
 
@@ -329,12 +325,11 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        @deprecated  # pylint: disable=useless-object-inheritance
+        @deprecated
         class Class(object):
             '''
             Dummy deprecated class.
             '''
-            # pylint: disable=too-few-public-methods
             def __init__(self, *args, **kwargs):
                 self.args = args
                 self.kwargs = kwargs
@@ -373,12 +368,11 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        @deprecated  # pylint: disable=useless-object-inheritance
+        @deprecated
         class Class(object):
             '''
             Dummy deprecated class.
             '''
-            # pylint: disable=too-few-public-methods
             def __init__(self, *args, **kwargs):
                 self.args = args
                 self.kwargs = kwargs
@@ -387,7 +381,6 @@ class TestUtils(unittest.TestCase):
             '''
             Dummy class inheriting from a dummy deprecated class.
             '''
-            # pylint: disable=too-few-public-methods
             def __init__(self, *args, **kwargs):
                 super(Inherited, self).__init__(*args, **kwargs)
                 self.args = args

--- a/plyer/utils.py
+++ b/plyer/utils.py
@@ -3,8 +3,6 @@ Utils
 =====
 
 '''
-# pylint: disable=useless-object-inheritance
-
 __all__ = ('platform', 'reify', 'deprecated')
 
 from os import environ
@@ -53,7 +51,6 @@ class Platform(object):
         # On android, _sys_platform return 'linux2', so prefer to check the
         # import of Android module than trying to rely on _sys_platform.
 
-        # pylint: disable=no-else-return
         if self._platform_android is True:
             return 'android'
         elif self._platform_ios is True:
@@ -67,7 +64,7 @@ class Platform(object):
         return 'unknown'
 
 
-platform = Platform()  # pylint: disable=invalid-name
+platform = Platform()
 
 
 class Proxy(object):
@@ -152,7 +149,6 @@ def whereis_exe(program):
 
 
 class reify(object):
-    # pylint: disable=too-few-public-methods,invalid-name
     '''
     Put the result of a method which uses this (non-data) descriptor decorator
     in the instance dict after the first call, effectively replacing the
@@ -247,8 +243,6 @@ def deprecated(obj):
             Custom metaclass instance's __new__ method with deprecated warning.
             Calls the original __new__ method afterwards.
             '''
-            # pylint: disable=unused-argument
-
             # get the previous stack frame and extract file, line and caller
             # stack() -> caller()
             call_file, call_line, caller = stack()[1][1:4]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
                 'ios': ['pyobjus'],
                 'macosx': ['pyobjus'],
                 'android': ['pyjnius'],
-                'dev': ['mock', 'pycodestyle', 'pylint']
+                'dev': ['mock', 'flake8']
             }
         }
     )


### PR DESCRIPTION
As pylint and pycodestyle were replaced for flake8 in #544, this pull request removes them from the .py files.