### PR TITLE
Fixes linter errors

### DIFF
--- a/examples/accelerometer/using_graph/libs/garden/garden.graph/__init__.py
+++ b/examples/accelerometer/using_graph/libs/garden/garden.graph/__init__.py
@@ -22,7 +22,7 @@ a red line plot containing a sin wave on this range::
                   y_grid_label=True, x_grid_label=True, padding=5,
                   x_grid=True, y_grid=True, xmin=-0, xmax=100, ymin=-1, ymax=1)
     plot = MeshLinePlot(color=[1, 0, 0, 1])
-    plot.points = [(x, sin(x / 10.)) for x in xrange(0, 101)]
+    plot.points = [(x, sin(x / 10.)) for x in range(0, 101)]
     graph.add_plot(plot)
 
 The MeshLinePlot plot is a particular plot which draws a set of points using
@@ -122,7 +122,7 @@ class Graph(Widget):
         self.canvas.add(self._mesh_rect)
         mesh = self._mesh_rect
         mesh.vertices = [0] * (5 * 4)
-        mesh.indices = [k for k in xrange(5)]
+        mesh.indices = [k for k in range(5)]
 
         self._plot_area = StencilView()
         self.add_widget(self._plot_area)
@@ -224,7 +224,7 @@ class Graph(Widget):
                 points_minor = [0] * (n_ticks - len(points_major) + 1)
                 k = 0  # position in points major
                 k2 = 0  # position in points minor
-                for m in xrange(0, n_ticks):
+                for m in range(0, n_ticks):
                     if minor and m % minor:
                         points_minor[k2] = m * tick_dist + s_min
                         k2 += 1
@@ -293,7 +293,7 @@ class Graph(Widget):
             y_start -= y1[1] / 2.
             func = (lambda x: 10 ** x) if self.ylog else lambda x: x
             y1 = y1[0]
-            for k in xrange(len(ylabels)):
+            for k in range(len(ylabels)):
                 ylabels[k].text = precision % func(ypoints[k])
                 ylabels[k].texture_update()
                 ylabels[k].size = ylabels[k].texture_size
@@ -319,7 +319,7 @@ class Graph(Widget):
             ratio = (xextent - x_next) / float(func(self.xmax) - xmin)
             func = (lambda x: 10 ** x) if self.xlog else lambda x: x
             right = -1
-            for k in xrange(len(xlabels)):
+            for k in range(len(xlabels)):
                 xlabels[k].text = precision % func(xpoints[k])
                 # update the size so we can center the labels on ticks
                 xlabels[k].texture_update()
@@ -343,10 +343,10 @@ class Graph(Widget):
                                                              -ylabel.center[1],
                                                              0))
         if x_overlap:
-            for k in xrange(len(xlabels)):
+            for k in range(len(xlabels)):
                 xlabels[k].text = ''
         if y_overlap:
-            for k in xrange(len(ylabels)):
+            for k in range(len(ylabels)):
                 ylabels[k].text = ''
         return x_next, y_next, xextent, yextent
 
@@ -366,7 +366,7 @@ class Graph(Widget):
             vert[16] = size[0]
             vert[17] = size[1]
         else:
-            vert[0:18] = [0 for k in xrange(18)]
+            vert[0:18] = [0 for k in range(18)]
         mesh.vertices = vert
         # re-compute the positions of the x/y axis ticks
         mesh = self._mesh
@@ -389,7 +389,7 @@ class Graph(Widget):
         if len(xpoints):
             top = size[3] if self.x_grid else metrics.dp(12) + size[1]
             ratio = (size[2] - size[0]) / float(xmax - xmin)
-            for k in xrange(start, len(xpoints) + start):
+            for k in range(start, len(xpoints) + start):
                 vert[k * 8] = size[0] + (xpoints[k - start] - xmin) * ratio
                 vert[k * 8 + 1] = size[1]
                 vert[k * 8 + 4] = vert[k * 8]
@@ -398,7 +398,7 @@ class Graph(Widget):
         if len(ypoints):
             top = size[2] if self.y_grid else metrics.dp(12) + size[0]
             ratio = (size[3] - size[1]) / float(ymax - ymin)
-            for k in xrange(start, len(ypoints) + start):
+            for k in range(start, len(ypoints) + start):
                 vert[k * 8 + 1] = size[1] + (ypoints[k - start] - ymin) * ratio
                 vert[k * 8 + 5] = vert[k * 8 + 1]
                 vert[k * 8] = size[0]
@@ -439,12 +439,12 @@ class Graph(Widget):
             n_labels = 0
         else:
             n_labels = len(xpoints_major)
-        for k in xrange(n_labels, len(grids)):
+        for k in range(n_labels, len(grids)):
             self.remove_widget(grids[k])
         del grids[n_labels:]
         grid_len = len(grids)
         grids.extend([None] * (n_labels - len(grids)))
-        for k in xrange(grid_len, n_labels):
+        for k in range(grid_len, n_labels):
             grids[k] = Label(font_size=font_size)
             self.add_widget(grids[k])
 
@@ -469,12 +469,12 @@ class Graph(Widget):
             n_labels = 0
         else:
             n_labels = len(ypoints_major)
-        for k in xrange(n_labels, len(grids)):
+        for k in range(n_labels, len(grids)):
             self.remove_widget(grids[k])
         del grids[n_labels:]
         grid_len = len(grids)
         grids.extend([None] * (n_labels - len(grids)))
-        for k in xrange(grid_len, n_labels):
+        for k in range(grid_len, n_labels):
             grids[k] = Label(font_size=font_size)
             self.add_widget(grids[k])
 
@@ -482,7 +482,7 @@ class Graph(Widget):
         n_points = (len(xpoints_major) + len(xpoints_minor)
                     + len(ypoints_major) + len(ypoints_minor))
         mesh.vertices = [0] * (n_points * 8)
-        mesh.indices = [k for k in xrange(n_points * 2)]
+        mesh.indices = [k for k in range(n_points * 2)]
         self._redraw_size()
 
     def _redraw_size(self, *args):
@@ -504,7 +504,7 @@ class Graph(Widget):
 
         >>> graph = Graph()
         >>> plot = MeshLinePlot(mode='line_strip', color=[1, 0, 0, 1])
-        >>> plot.points = [(x / 10., sin(x / 50.)) for x in xrange(-0, 101)]
+        >>> plot.points = [(x / 10., sin(x / 50.)) for x in range(-0, 101)]
         >>> graph.add_plot(plot)
         '''
         area = self._plot_area
@@ -521,7 +521,7 @@ class Graph(Widget):
 
         >>> graph = Graph()
         >>> plot = MeshLinePlot(mode='line_strip', color=[1, 0, 0, 1])
-        >>> plot.points = [(x / 10., sin(x / 50.)) for x in xrange(-0, 101)]
+        >>> plot.points = [(x / 10., sin(x / 50.)) for x in range(-0, 101)]
         >>> graph.add_plot(plot)
         >>> graph.remove_plot(plot)
         '''
@@ -795,9 +795,9 @@ class MeshLinePlot(Plot):
             del vert[4 * len(points):]
             del ind[len(points):]
         elif diff > 0:
-            ind.extend(xrange(len(ind), len(ind) + diff))
+            ind.extend(range(len(ind), len(ind) + diff))
             vert.extend([0] * (diff * 4))
-        for k in xrange(len(points)):
+        for k in range(len(points)):
             vert[k * 4] = (funcx(points[k][0]) - xmin) * ratiox + size[0]
             vert[k * 4 + 1] = (funcy(points[k][1]) - ymin) * ratioy + size[1]
         mesh.vertices = vert
@@ -861,9 +861,9 @@ class MeshStemPlot(MeshLinePlot):
             del vert[4 * len(points):]
             del ind[len(points):]
         elif diff > 0:
-            ind.extend(xrange(len(ind), len(ind) + diff))
+            ind.extend(range(len(ind), len(ind) + diff))
             vert.extend([0] * (diff * 4))
-        for k in xrange(len(points)):
+        for k in range(len(points)):
             vert[k * 8] = (funcx(points[k][0]) - xmin) * ratiox + size[0]
             vert[k * 8 + 1] = (0 - ymin) * ratioy + size[1]
             vert[k * 8 + 4] = (funcx(points[k][0]) - xmin) * ratiox + size[0]
@@ -885,14 +885,14 @@ if __name__ == '__main__':
                           xlog=False, ylog=False, x_grid=True, y_grid=True,
                           xmin=-50, xmax=50, ymin=-1, ymax=1)
             plot = MeshLinePlot(color=[1, 0, 0, 1])
-            plot.points = [(x / 10., sin(x / 50.)) for x in xrange(-500, 501)]
+            plot.points = [(x / 10., sin(x / 50.)) for x in range(-500, 501)]
             graph.add_plot(plot)
             plot = MeshLinePlot(color=[0, 1, 0, 1])
-            plot.points = [(x / 10., cos(x / 50.)) for x in xrange(-600, 501)]
+            plot.points = [(x / 10., cos(x / 50.)) for x in range(-600, 501)]
             graph.add_plot(plot)
             plot = MeshLinePlot(color=[0, 0, 1, 1])
             graph.add_plot(plot)
-            plot.points = [(x, x / 50.) for x in xrange(-50, 51)]
+            plot.points = [(x, x / 50.) for x in range(-50, 51)]
             return graph
 
     TestApp().run()

--- a/plyer/compat.py
+++ b/plyer/compat.py
@@ -5,7 +5,7 @@ Compatibility module for Python 2.7 and > 3.3
 # pylint: disable=invalid-name
 
 __all__ = ('PY2', 'string_types', 'queue', 'iterkeys',
-           'itervalues', 'iteritems', 'xrange')
+           'itervalues', 'iteritems')
 
 import sys
 try:
@@ -22,23 +22,16 @@ text_type = None
 if PY2:
     # pylint: disable=undefined-variable
     # built-in actually, so it is defined in globals() for py2
-    string_types = basestring
-    text_type = unicode
+    string_types = basestring  # noqa F821 undefined name 'basestring'
+    text_type = unicode  # noqa F821 undefined name 'unicode'
 else:
     string_types = text_type = str
 
 if PY2:
-    iterkeys = lambda d: d.iterkeys()
-    itervalues = lambda d: d.itervalues()
-    iteritems = lambda d: d.iteritems()
+    def iterkeys(d): return d.iterkeys()
+    def itervalues(d): return d.itervalues()
+    def iteritems(d): return d.iteritems()
 else:
-    iterkeys = lambda d: iter(d.keys())
-    itervalues = lambda d: iter(d.values())
-    iteritems = lambda d: iter(d.items())
-
-if PY2:
-    # pylint: disable=undefined-variable
-    # built-in actually, so it is defined in globals() for py2
-    xrange = xrange
-else:
-    xrange = range
+    def iterkeys(d): return iter(d.keys())
+    def itervalues(d): return iter(d.values())
+    def iteritems(d): return iter(d.items())

--- a/plyer/platforms/win/libs/wifi_defs.py
+++ b/plyer/platforms/win/libs/wifi_defs.py
@@ -512,7 +512,7 @@ def _make_dict():
     for network in available:
         # if bytes, dict['name'] throws an error on py3 if not b'name'
         if PY2:
-            _dict[unicode(network.dot11Ssid.SSID)] = network
+            _dict[unicode(network.dot11Ssid.SSID)] = network  # noqa F821 undefined name 'unicode'
         else:
             _dict[network.dot11Ssid.SSID.decode('utf-8')] = network
 

--- a/plyer/tools/pep8checker/pep8.py
+++ b/plyer/tools/pep8checker/pep8.py
@@ -21,7 +21,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+# flake8: noqa
 r"""
 Check Python source code formatting, according to PEP 8:
 http://www.python.org/dev/peps/pep-0008/


### PR DESCRIPTION
This is a follow up for https://github.com/kivy/plyer/pull/548
Note that we ignore the `plyer/tools/pep8checker/pep8.py` entirely as it
contains major issues such as `F821 undefined name`. I'd rather
completely delete this file and only rely on existing linting tools
rather using a custom one.