### PR TITLE
Uses Python 3 syntax

### DIFF
--- a/examples/accelerometer/basic/main.py
+++ b/examples/accelerometer/basic/main.py
@@ -11,7 +11,7 @@ from plyer import accelerometer
 
 class AccelerometerTest(BoxLayout):
     def __init__(self):
-        super(AccelerometerTest, self).__init__()
+        super().__init__()
         self.sensorEnabled = False
 
     def do_toggle(self):

--- a/examples/accelerometer/using_graph/libs/garden/garden.graph/__init__.py
+++ b/examples/accelerometer/using_graph/libs/garden/garden.graph/__init__.py
@@ -111,7 +111,7 @@ class Graph(Widget):
     _ticks_minory = ListProperty([])
 
     def __init__(self, **kwargs):
-        super(Graph, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._mesh = Mesh(mode='lines')
         self._mesh_rect = Mesh(mode='line_strip')
@@ -768,7 +768,7 @@ class MeshLinePlot(Plot):
     def __init__(self, **kwargs):
         self._color = Color(1, 1, 1, group='LinePlot%d' % id(self))
         self._mesh = Mesh(mode='line_strip', group='LinePlot%d' % id(self))
-        super(MeshLinePlot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._trigger = Clock.create_trigger(self._redraw)
         self.bind(_params=self._trigger, points=self._trigger)

--- a/examples/accelerometer/using_graph/main.py
+++ b/examples/accelerometer/using_graph/main.py
@@ -20,7 +20,7 @@ kivy.require('1.8.0')
 
 class AccelerometerDemo(BoxLayout):
     def __init__(self):
-        super(AccelerometerDemo, self).__init__()
+        super().__init__()
 
         self.sensorEnabled = False
         self.graph = self.ids.graph_plot

--- a/examples/camera/basic/main.py
+++ b/examples/camera/basic/main.py
@@ -19,7 +19,7 @@ kivy.require('1.8.0')
 
 class CameraDemo(FloatLayout):
     def __init__(self):
-        super(CameraDemo, self).__init__()
+        super().__init__()
         self.cwd = getcwd() + "/"
         self.ids.path_label.text = self.cwd
 
@@ -50,7 +50,7 @@ class CameraDemo(FloatLayout):
 
 class CameraDemoApp(App):
     def __init__(self):
-        super(CameraDemoApp, self).__init__()
+        super().__init__()
         self.demo = None
 
     def build(self):
@@ -66,7 +66,7 @@ class CameraDemoApp(App):
 
 class MsgPopup(Popup):
     def __init__(self, msg):
-        super(MsgPopup, self).__init__()
+        super().__init__()
         self.ids.message_label.text = msg
 
 

--- a/examples/filechooser/main.py
+++ b/examples/filechooser/main.py
@@ -2,7 +2,6 @@
 Example of an Android filechooser.
 '''
 
-from __future__ import unicode_literals
 from textwrap import dedent
 
 from plyer import filechooser

--- a/examples/gravity/main.py
+++ b/examples/gravity/main.py
@@ -41,7 +41,7 @@ Builder.load_string('''
 
 class GravityInterface(BoxLayout):
     def __init__(self):
-        super(GravityInterface, self).__init__()
+        super().__init__()
         self.sensorEnabled = False
 
     def do_toggle(self):

--- a/examples/wifi/main.py
+++ b/examples/wifi/main.py
@@ -106,7 +106,7 @@ class WifiInterface(BoxLayout):
         for name in wifi_scans:
             content = ""
             items = wifi._get_network_info(name)
-            for key, value in items.iteritems():
+            for key, value in items.items():
                 content += "{}:    {} \n".format(key, value)
 
             popup = self._create_popup(name, content)

--- a/plyer/facades/accelerometer.py
+++ b/plyer/facades/accelerometer.py
@@ -33,7 +33,7 @@ Android, iOS, OS X, Linux
 '''
 
 
-class Accelerometer(object):
+class Accelerometer:
     '''
     Accelerometer facade.
     '''

--- a/plyer/facades/audio.py
+++ b/plyer/facades/audio.py
@@ -46,7 +46,7 @@ Android
 '''
 
 
-class Audio(object):
+class Audio:
     '''
     Audio facade.
     '''
@@ -55,7 +55,7 @@ class Audio(object):
     _file_path = ''
 
     def __init__(self, file_path=None):
-        super(Audio, self).__init__()
+        super().__init__()
         self._file_path = file_path or self._file_path
 
     def start(self):

--- a/plyer/facades/barometer.py
+++ b/plyer/facades/barometer.py
@@ -1,4 +1,4 @@
-class Barometer(object):
+class Barometer:
     '''Barometer facade.
 
     Barometer sensor is used to measure the ambient air pressure in hPa.

--- a/plyer/facades/battery.py
+++ b/plyer/facades/battery.py
@@ -23,7 +23,7 @@ Android, iOS, Windows, OS X, Linux
 '''
 
 
-class Battery(object):
+class Battery:
     '''
     Battery info facade.
     '''

--- a/plyer/facades/bluetooth.py
+++ b/plyer/facades/bluetooth.py
@@ -22,7 +22,7 @@ Android, OS X
 '''
 
 
-class Bluetooth(object):
+class Bluetooth:
     '''
     Bluetooth facade.
     '''

--- a/plyer/facades/brightness.py
+++ b/plyer/facades/brightness.py
@@ -27,7 +27,7 @@ Android, iOS, Linux
 '''
 
 
-class Brightness(object):
+class Brightness:
     '''
     Brightness facade.
     '''

--- a/plyer/facades/call.py
+++ b/plyer/facades/call.py
@@ -30,7 +30,7 @@ Android, iOS
 '''
 
 
-class Call(object):
+class Call:
     '''
     Call facade.
     '''

--- a/plyer/facades/camera.py
+++ b/plyer/facades/camera.py
@@ -42,7 +42,7 @@ Android, iOS
 '''
 
 
-class Camera(object):
+class Camera:
     '''
     Camera facade.
     '''

--- a/plyer/facades/compass.py
+++ b/plyer/facades/compass.py
@@ -37,7 +37,7 @@ Android, iOS
 '''
 
 
-class Compass(object):
+class Compass:
     '''Compass facade.
 
     .. versionadded:: 1.2.0

--- a/plyer/facades/cpu.py
+++ b/plyer/facades/cpu.py
@@ -24,7 +24,7 @@ Windows
 '''
 
 
-class CPU(object):
+class CPU:
     '''
     Facade providing info about sockets, physical and logical
     number of processors.

--- a/plyer/facades/email.py
+++ b/plyer/facades/email.py
@@ -30,7 +30,7 @@ Android, iOS, Windows, OS X, Linux
 '''
 
 
-class Email(object):
+class Email:
     '''
     Email facade.
     '''

--- a/plyer/facades/filechooser.py
+++ b/plyer/facades/filechooser.py
@@ -38,7 +38,7 @@ Use threads or you will stop the mainloop if your app has one.
 '''
 
 
-class FileChooser(object):
+class FileChooser:
     '''
     File Chooser facade.
     '''

--- a/plyer/facades/flash.py
+++ b/plyer/facades/flash.py
@@ -38,7 +38,7 @@ Android, iOS
 '''
 
 
-class Flash(object):
+class Flash:
     """
     Flash facade.
     """

--- a/plyer/facades/gps.py
+++ b/plyer/facades/gps.py
@@ -45,7 +45,7 @@ Android, iOS
 '''
 
 
-class GPS(object):
+class GPS:
     '''
     GPS facade.
     '''

--- a/plyer/facades/gravity.py
+++ b/plyer/facades/gravity.py
@@ -1,4 +1,4 @@
-class Gravity(object):
+class Gravity:
     '''Gravity facade.
 
     .. versionadded:: 1.2.5

--- a/plyer/facades/gyroscope.py
+++ b/plyer/facades/gyroscope.py
@@ -41,7 +41,7 @@ Android, iOS
 '''
 
 
-class Gyroscope(object):
+class Gyroscope:
     '''
     Gyroscope facade.
 

--- a/plyer/facades/humidity.py
+++ b/plyer/facades/humidity.py
@@ -1,4 +1,4 @@
-class Humidity(object):
+class Humidity:
     '''Humidity facade.
        Humidity sensor returns value of humidity.
        With method `enable` you can turn on Humidity sensor and

--- a/plyer/facades/irblaster.py
+++ b/plyer/facades/irblaster.py
@@ -34,7 +34,7 @@ Android
 '''
 
 
-class IrBlaster(object):
+class IrBlaster:
     '''
     Infrared blaster facade.
     '''

--- a/plyer/facades/keystore.py
+++ b/plyer/facades/keystore.py
@@ -1,4 +1,4 @@
-class Keystore(object):
+class Keystore:
     '''
     Keyring facade
 

--- a/plyer/facades/light.py
+++ b/plyer/facades/light.py
@@ -1,4 +1,4 @@
-class Light(object):
+class Light:
     '''Light facade.
 
     Light sensor measures the ambient light level(illumination) in lx.

--- a/plyer/facades/notification.py
+++ b/plyer/facades/notification.py
@@ -40,7 +40,7 @@ Notification with custom icon::
 '''
 
 
-class Notification(object):
+class Notification:
     '''
     Notification facade.
     '''

--- a/plyer/facades/orientation.py
+++ b/plyer/facades/orientation.py
@@ -35,7 +35,7 @@ Android
 '''
 
 
-class Orientation(object):
+class Orientation:
     '''
     Orientation facade.
     '''

--- a/plyer/facades/processors.py
+++ b/plyer/facades/processors.py
@@ -14,7 +14,7 @@ Linux
 '''
 
 
-class Processors(object):
+class Processors:
     '''
     Number of Processors info facade.
     '''

--- a/plyer/facades/proximity.py
+++ b/plyer/facades/proximity.py
@@ -1,4 +1,4 @@
-class Proximity(object):
+class Proximity:
     '''Proximity facade.
 
     The proximity sensor is commonly used to determine distance whether

--- a/plyer/facades/screenshot.py
+++ b/plyer/facades/screenshot.py
@@ -26,7 +26,7 @@ To take screenshot::
 '''
 
 
-class Screenshot(object):
+class Screenshot:
     '''
     Screenshot facade.
     '''

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -28,7 +28,7 @@ Android, iOS
 '''
 
 
-class Sms(object):
+class Sms:
     '''
     Sms facade.
     '''

--- a/plyer/facades/spatialorientation.py
+++ b/plyer/facades/spatialorientation.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 
-class SpatialOrientation(object):
+class SpatialOrientation:
     '''Spatial Orientation facade.
 
     Computes the device's orientation based on the rotation matrix.

--- a/plyer/facades/storagepath.py
+++ b/plyer/facades/storagepath.py
@@ -30,7 +30,7 @@ To get the path of directory holding application files::
 '''
 
 
-class StoragePath(object):
+class StoragePath:
     '''
     StoragePath facade.
     '''

--- a/plyer/facades/stt.py
+++ b/plyer/facades/stt.py
@@ -73,7 +73,7 @@ To retrieve results after the listening stopped::
 '''
 
 
-class STT(object):
+class STT:
     '''
     Speech to text facade.
     '''

--- a/plyer/facades/temperature.py
+++ b/plyer/facades/temperature.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 
-class Temperature(object):
+class Temperature:
     '''Temperature facade.
 
     Temperature sensor is used to measure the ambient room temperature in

--- a/plyer/facades/tts.py
+++ b/plyer/facades/tts.py
@@ -20,7 +20,7 @@ Android, iOS, Windows, OS X, Linux
 '''
 
 
-class TTS(object):
+class TTS:
     '''
     TextToSpeech facade.
     '''

--- a/plyer/facades/uniqueid.py
+++ b/plyer/facades/uniqueid.py
@@ -29,7 +29,7 @@ Android, iOS, Windows, OS X, Linux
 '''
 
 
-class UniqueID(object):
+class UniqueID:
     '''
     UniqueID facade.
     '''

--- a/plyer/facades/vibrator.py
+++ b/plyer/facades/vibrator.py
@@ -38,7 +38,7 @@ Android, iOS
 '''
 
 
-class Vibrator(object):
+class Vibrator:
     '''
     Vibration facade.
     '''

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -82,7 +82,7 @@ This disable wifi device
 '''
 
 
-class Wifi(object):
+class Wifi:
     '''
     Wifi Facade.
     '''

--- a/plyer/platforms/android/accelerometer.py
+++ b/plyer/platforms/android/accelerometer.py
@@ -16,7 +16,7 @@ class AccelerometerSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(AccelerometerSensorListener, self).__init__()
+        super().__init__()
         self.SensorManager = cast(
             'android.hardware.SensorManager',
             activity.getSystemService(Context.SENSOR_SERVICE)
@@ -48,7 +48,7 @@ class AccelerometerSensorListener(PythonJavaClass):
 
 class AndroidAccelerometer(Accelerometer):
     def __init__(self):
-        super(AndroidAccelerometer, self).__init__()
+        super().__init__()
         self.bState = False
 
     def _enable(self):
@@ -72,7 +72,7 @@ class AndroidAccelerometer(Accelerometer):
     def __del__(self):
         if(self.bState):
             self._disable()
-        super(self.__class__, self).__del__()
+        super().__del__()
 
 
 def instance():

--- a/plyer/platforms/android/audio.py
+++ b/plyer/platforms/android/audio.py
@@ -21,7 +21,7 @@ class AndroidAudio(Audio):
 
     def __init__(self, file_path=None):
         default_path = '/sdcard/testrecorder.3gp'
-        super(AndroidAudio, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
         self._recorder = None
         self._player = None

--- a/plyer/platforms/android/barometer.py
+++ b/plyer/platforms/android/barometer.py
@@ -16,7 +16,7 @@ class BarometerSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(BarometerSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 

--- a/plyer/platforms/android/compass.py
+++ b/plyer/platforms/android/compass.py
@@ -16,7 +16,7 @@ class MFUSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(MFUSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 
@@ -46,7 +46,7 @@ class MagneticFieldSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(MagneticFieldSensorListener, self).__init__()
+        super().__init__()
         self.SensorManager = cast(
             'android.hardware.SensorManager',
             activity.getSystemService(Context.SENSOR_SERVICE)
@@ -78,7 +78,7 @@ class MagneticFieldSensorListener(PythonJavaClass):
 
 class AndroidCompass(Compass):
     def __init__(self):
-        super(AndroidCompass, self).__init__()
+        super().__init__()
         self.bState = False
 
     def _enable(self):
@@ -112,7 +112,7 @@ class AndroidCompass(Compass):
     def __del__(self):
         if(self.bState):
             self._disable()
-        super(self.__class__, self).__del__()
+        super().__del__()
 
 
 def instance():

--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -43,7 +43,6 @@ using that result will use an incorrect one i.e. the default value of
 .. versionadded:: 1.4.0
 '''
 
-from __future__ import unicode_literals
 from os.path import join, basename
 from random import randint
 
@@ -80,7 +79,7 @@ class AndroidFileChooser(FileChooser):
     selection = None
 
     def __init__(self, *args, **kwargs):
-        super(AndroidFileChooser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.select_code = randint(123456, 654321)
         self.selection = None
 

--- a/plyer/platforms/android/gps.py
+++ b/plyer/platforms/android/gps.py
@@ -17,7 +17,7 @@ class _LocationListener(PythonJavaClass):
 
     def __init__(self, root):
         self.root = root
-        super(_LocationListener, self).__init__()
+        super().__init__()
 
     @java_method('(Landroid/location/Location;)V')
     def onLocationChanged(self, location):

--- a/plyer/platforms/android/gravity.py
+++ b/plyer/platforms/android/gravity.py
@@ -20,7 +20,7 @@ class GravitySensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(GravitySensorListener, self).__init__()
+        super().__init__()
 
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
@@ -53,7 +53,7 @@ class GravitySensorListener(PythonJavaClass):
 class AndroidGravity(Gravity):
 
     def __init__(self):
-        super(AndroidGravity, self).__init__()
+        super().__init__()
         self.state = False
 
     def _enable(self):
@@ -77,7 +77,7 @@ class AndroidGravity(Gravity):
     def __del__(self):
         if self.state:
             self._disable()
-        super(self.__class__, self).__del__()
+        super().__del__()
 
 
 def instance():

--- a/plyer/platforms/android/gyroscope.py
+++ b/plyer/platforms/android/gyroscope.py
@@ -16,7 +16,7 @@ class GyroscopeSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(GyroscopeSensorListener, self).__init__()
+        super().__init__()
         self.SensorManager = cast(
             'android.hardware.SensorManager',
             activity.getSystemService(Context.SENSOR_SERVICE)
@@ -50,7 +50,7 @@ class GyroUncalibratedSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(GyroUncalibratedSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 
@@ -78,7 +78,7 @@ class GyroUncalibratedSensorListener(PythonJavaClass):
 
 class AndroidGyroscope(Gyroscope):
     def __init__(self):
-        super(AndroidGyroscope, self).__init__()
+        super().__init__()
         self.bState = False
 
     def _enable(self):
@@ -112,7 +112,7 @@ class AndroidGyroscope(Gyroscope):
     def __del__(self):
         if(self.bState):
             self._disable()
-        super(self.__class__, self).__del__()
+        super().__del__()
 
 
 def instance():

--- a/plyer/platforms/android/humidity.py
+++ b/plyer/platforms/android/humidity.py
@@ -16,7 +16,7 @@ class RelativeHumiditySensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(RelativeHumiditySensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 
@@ -44,7 +44,7 @@ class AmbientTemperatureSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(AmbientTemperatureSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 

--- a/plyer/platforms/android/light.py
+++ b/plyer/platforms/android/light.py
@@ -15,7 +15,7 @@ class LightSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(LightSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
         self.sensor = self.SensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)

--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -15,7 +15,6 @@ Module of Android API for plyer.notification.
     Added option for custom big icon via `icon`.
 '''
 
-from __future__ import unicode_literals
 from android import python_act
 from android.runnable import run_on_ui_thread
 from jnius import autoclass, cast

--- a/plyer/platforms/android/proximity.py
+++ b/plyer/platforms/android/proximity.py
@@ -16,7 +16,7 @@ class ProximitySensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(ProximitySensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 

--- a/plyer/platforms/android/spatialorientation.py
+++ b/plyer/platforms/android/spatialorientation.py
@@ -14,7 +14,7 @@ class AccelerometerSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(AccelerometerSensorListener, self).__init__()
+        super().__init__()
         self.SensorManager = cast(
             'android.hardware.SensorManager',
             activity.getSystemService(Context.SENSOR_SERVICE)
@@ -46,7 +46,7 @@ class MagnetometerSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(MagnetometerSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 

--- a/plyer/platforms/android/stt.py
+++ b/plyer/platforms/android/stt.py
@@ -29,7 +29,7 @@ class SpeechListener(PythonJavaClass):
     _volume_callback = None
 
     def __init__(self):
-        super(SpeechListener, self).__init__()
+        super().__init__()
 
         # overwrite class variables in the object
         self._error_callback = None

--- a/plyer/platforms/android/temperature.py
+++ b/plyer/platforms/android/temperature.py
@@ -16,7 +16,7 @@ class TemperatureSensorListener(PythonJavaClass):
     __javainterfaces__ = ['android/hardware/SensorEventListener']
 
     def __init__(self):
-        super(TemperatureSensorListener, self).__init__()
+        super().__init__()
         service = activity.getSystemService(Context.SENSOR_SERVICE)
         self.SensorManager = cast('android.hardware.SensorManager', service)
 

--- a/plyer/platforms/ios/accelerometer.py
+++ b/plyer/platforms/ios/accelerometer.py
@@ -13,7 +13,7 @@ from pyobjus import autoclass
 class IosAccelerometer(Accelerometer):
 
     def __init__(self):
-        super(IosAccelerometer, self).__init__()
+        super().__init__()
         self.bridge = autoclass('bridge').alloc().init()
         self.bridge.motionManager.setAccelerometerUpdateInterval_(0.1)
 

--- a/plyer/platforms/ios/barometer.py
+++ b/plyer/platforms/ios/barometer.py
@@ -10,7 +10,7 @@ from pyobjus import autoclass
 class iOSBarometer(Barometer):
 
     def __init__(self):
-        super(iOSBarometer, self).__init__()
+        super().__init__()
         self.bridge = autoclass('bridge').alloc().init()
 
     def _enable(self):

--- a/plyer/platforms/ios/battery.py
+++ b/plyer/platforms/ios/battery.py
@@ -16,7 +16,7 @@ class IOSBattery(Battery):
     '''
 
     def __init__(self):
-        super(IOSBattery, self).__init__()
+        super().__init__()
         self.device = UIDevice.currentDevice()
 
     def _get_state(self):

--- a/plyer/platforms/ios/compass.py
+++ b/plyer/platforms/ios/compass.py
@@ -10,7 +10,7 @@ from pyobjus import autoclass
 class IosCompass(Compass):
 
     def __init__(self):
-        super(IosCompass, self).__init__()
+        super().__init__()
         self.bridge = autoclass('bridge').alloc().init()
         self.bridge.motionManager.setMagnetometerUpdateInterval_(0.1)
         self.bridge.motionManager.setDeviceMotionUpdateInterval_(0.1)

--- a/plyer/platforms/ios/filechooser.py
+++ b/plyer/platforms/ios/filechooser.py
@@ -24,7 +24,7 @@ class IOSFileChooser(FileChooser):
     '''
 
     def __init__(self, *args, **kwargs):
-        super(IOSFileChooser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._on_selection = None
 
     def _file_selection_dialog(self, *args, **kwargs):

--- a/plyer/platforms/ios/gyroscope.py
+++ b/plyer/platforms/ios/gyroscope.py
@@ -17,7 +17,7 @@ device = UIDevice.currentDevice()
 class IosGyroscope(Gyroscope):
 
     def __init__(self):
-        super(IosGyroscope, self).__init__()
+        super().__init__()
         self.bridge = autoclass('bridge').alloc().init()
 
         if int(device.systemVersion.UTF8String().split('.')[0]) <= 4:

--- a/plyer/platforms/ios/tts.py
+++ b/plyer/platforms/ios/tts.py
@@ -11,7 +11,7 @@ AVSpeechSynthesisVoice = autoclass('AVSpeechSynthesisVoice')
 
 class iOSTextToSpeech(TTS):
     def __init__(self):
-        super(iOSTextToSpeech, self).__init__()
+        super().__init__()
         self.synth = AVSpeechSynthesizer.alloc().init()
         self.voice = None
 

--- a/plyer/platforms/ios/vibrator.py
+++ b/plyer/platforms/ios/vibrator.py
@@ -15,7 +15,7 @@ class IosVibrator(Vibrator):
     '''
 
     def __init__(self):
-        super(IosVibrator, self).__init__()
+        super().__init__()
         try:
             self._func = ctypes.CDLL(None).AudioServicesPlaySystemSound
         except AttributeError:

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -10,7 +10,7 @@ import subprocess as sp
 import time
 
 
-class SubprocessFileChooser(object):
+class SubprocessFileChooser:
     '''A file chooser implementation that allows using
     subprocess back-ends.
     Normally you only need to override _gen_cmdline, executable,

--- a/plyer/platforms/linux/screenshot.py
+++ b/plyer/platforms/linux/screenshot.py
@@ -11,7 +11,7 @@ class LinuxScreenshot(Screenshot):
             LinuxStoragePath().get_pictures_dir(),
             'screenshot.xwd'
         )
-        super(LinuxScreenshot, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
     def _capture(self):
         # call xwd and redirect bytes from stdout to file

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -27,7 +27,7 @@ class NMCLIWifi(Wifi):
         .. versionadded:: 1.4.0
         '''
 
-        super(NMCLIWifi, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.names = {}
 
     @property
@@ -292,7 +292,7 @@ class LinuxWifi(Wifi):
         .. versionadded:: 1.4.0
         '''
 
-        super(LinuxWifi, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.names = {}
 
     @property

--- a/plyer/platforms/macosx/audio.py
+++ b/plyer/platforms/macosx/audio.py
@@ -23,7 +23,7 @@ class OSXAudio(Audio):
             OSXStoragePath().get_music_dir(),
             'audio.wav'
         )
-        super(OSXAudio, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
         self._recorder = None
         self._player = None

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -14,7 +14,7 @@ NSSavePanel = autoclass('NSSavePanel')
 NSOKButton = 1
 
 
-class MacFileChooser(object):
+class MacFileChooser:
     '''A native implementation of file chooser dialogs using Apple's API
     through pyobjus.
 

--- a/plyer/platforms/macosx/screenshot.py
+++ b/plyer/platforms/macosx/screenshot.py
@@ -11,7 +11,7 @@ class OSXScreenshot(Screenshot):
             OSXStoragePath().get_pictures_dir().replace('file://', ''),
             'screenshot.png'
         )
-        super(OSXScreenshot, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
     def _capture(self):
         subprocess.call([

--- a/plyer/platforms/win/audio.py
+++ b/plyer/platforms/win/audio.py
@@ -5,7 +5,6 @@ http://docs.microsoft.com/en-us/windows/desktop/Multimedia
 .. versionadded:: 1.4.0
 '''
 
-from __future__ import unicode_literals
 from os.path import join
 
 from ctypes import windll
@@ -152,7 +151,7 @@ def send_command(device, msg, flags, params):
     return params
 
 
-class WinRecorder(object):
+class WinRecorder:
     '''
     Generic wrapper for MCI_RECORD handling the filenames and device closing
     in the same approach like it is used for other platforms.
@@ -234,7 +233,7 @@ class WinRecorder(object):
         )
 
 
-class WinPlayer(object):
+class WinPlayer:
     '''
     Generic wrapper for MCI_PLAY handling the device closing.
 
@@ -304,7 +303,7 @@ class WinAudio(Audio):
             WinStoragePath().get_music_dir(),
             'audio.wav'
         )
-        super(WinAudio, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
         self._recorder = None
         self._player = None

--- a/plyer/platforms/win/cpu.py
+++ b/plyer/platforms/win/cpu.py
@@ -18,7 +18,7 @@ KERNEL = windll.kernel32
 ERROR_INSUFFICIENT_BUFFER = 0x0000007A
 
 
-class CacheType(object):
+class CacheType:
     '''
     Win API PROCESSOR_CACHE_TYPE enum.
     '''
@@ -29,7 +29,7 @@ class CacheType(object):
     trace = 3
 
 
-class RelationshipType(object):
+class RelationshipType:
     '''
     Win API LOGICAL_PROCESSOR_RELATIONSHIP enum.
     '''

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -15,7 +15,7 @@ import pywintypes
 from os.path import dirname, splitext, join, isdir
 
 
-class Win32FileChooser(object):
+class Win32FileChooser:
     '''A native implementation of NativeFileChooser using the
     Win32 API on Windows.
 

--- a/plyer/platforms/win/libs/balloontip.py
+++ b/plyer/platforms/win/libs/balloontip.py
@@ -37,7 +37,7 @@ NIIF_USER = 4
 NIIF_LARGE_ICON = 0x20
 
 
-class WindowsBalloonTip(object):
+class WindowsBalloonTip:
     '''
     Implementation of balloon tip notifications through Windows API.
 

--- a/plyer/platforms/win/screenshot.py
+++ b/plyer/platforms/win/screenshot.py
@@ -27,7 +27,7 @@ class WinScreenshot(Screenshot):
         default_path = join(
             WinStoragePath().get_pictures_dir(), 'screenshot.bmp'
         )
-        super(WinScreenshot, self).__init__(file_path or default_path)
+        super().__init__(file_path or default_path)
 
     def _set_dpi_aware(self, value):
         try:

--- a/plyer/tests/common.py
+++ b/plyer/tests/common.py
@@ -14,7 +14,7 @@ from os.path import normpath, splitdrive
 from plyer.utils import platform as plyer_platform
 
 
-class PlatformTest(object):
+class PlatformTest:
     '''
     Class for the @PlatformTest decorator to prevent running tests
     calling platform dependent API on different platforms.

--- a/plyer/tests/test_audio.py
+++ b/plyer/tests/test_audio.py
@@ -10,7 +10,6 @@ Tested platforms:
 .. versionadded:: 1.4.0
 '''
 
-from __future__ import unicode_literals
 import unittest
 import time
 

--- a/plyer/tests/test_battery.py
+++ b/plyer/tests/test_battery.py
@@ -9,7 +9,6 @@ Tested platforms:
 * macOS - ioreg
 '''
 
-from __future__ import unicode_literals
 import unittest
 from io import BytesIO
 from os.path import join
@@ -19,7 +18,7 @@ from mock import patch, Mock
 from plyer.tests.common import PlatformTest, platform_import
 
 
-class MockedKernelSysclass(object):
+class MockedKernelSysclass:
     '''
     Mocked object used instead of Linux's sysclass for power_supply
     battery uevent.
@@ -88,7 +87,7 @@ class MockedKernelSysclass(object):
         )).encode('utf-8'))
 
 
-class MockedUPower(object):
+class MockedUPower:
     '''
     Mocked object used instead of 'upower' binary in the Linux specific API
     plyer.platforms.linux.battery. The same output structure is tested for
@@ -196,7 +195,7 @@ class MockedUPower(object):
         return float(percentage.replace(',', '.'))
 
 
-class MockedIOReg(object):
+class MockedIOReg:
     '''
     Mocked object used instead of Apple's ioreg.
     '''

--- a/plyer/tests/test_bluetooth.py
+++ b/plyer/tests/test_bluetooth.py
@@ -7,14 +7,13 @@ Tested platforms:
 * macOS - system_profiler
 '''
 
-from __future__ import unicode_literals
 import unittest
 
 from plyer.tests.common import platform_import
 from textwrap import dedent
 
 
-class MockedSystemProfiler(object):
+class MockedSystemProfiler:
     '''
     Mocked object used instead of Apple's system_profiler
     '''

--- a/plyer/tests/test_cpu.py
+++ b/plyer/tests/test_cpu.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 from plyer.tests.common import PlatformTest, platform_import, splitpath
 
 
-class MockedKernelCPU(object):
+class MockedKernelCPU:
     def __init__(self, *args, **kwargs):
         self.fname = args[0] if args else ''
         self.cpu_path = join('/sys', 'devices', 'system', 'cpu')
@@ -74,7 +74,7 @@ class MockedKernelCPU(object):
         }
 
 
-class MockedNProc(object):
+class MockedNProc:
     '''
     Mocked object used instead of 'nproc' binary in the Linux specific API
     plyer.platforms.linux.cpu. The same output structure is tested for
@@ -114,7 +114,7 @@ class MockedNProc(object):
         return int(MockedNProc.logical_cores)
 
 
-class MockedProcinfo(object):
+class MockedProcinfo:
     # docs:
     # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     # /tree/arch/x86/kernel/cpu/proc.c

--- a/plyer/tests/test_facade.py
+++ b/plyer/tests/test_facade.py
@@ -57,7 +57,7 @@ def mock_platform_module(mod, platform, cls):
 
 
 # dummy pyjnius class to silence the import + config
-class DummyJnius(object):
+class DummyJnius:
     '''
     Mocked PyJNIus module.
     '''

--- a/plyer/tests/test_notification.py
+++ b/plyer/tests/test_notification.py
@@ -18,7 +18,7 @@ from mock import Mock, patch
 from plyer.tests.common import PlatformTest, platform_import
 
 
-class MockedNotifySend(object):
+class MockedNotifySend:
     '''
     Mocked object used instead of the console-like calling
     of notify-send binary with parameters.

--- a/plyer/tests/test_screenshot.py
+++ b/plyer/tests/test_screenshot.py
@@ -17,7 +17,7 @@ from mock import patch
 from plyer.tests.common import PlatformTest, platform_import
 
 
-class MockedScreenCapture(object):
+class MockedScreenCapture:
     '''
     Mocked object used instead of the console-like calling
     of screencapture binary with parameters.
@@ -44,7 +44,7 @@ class MockedScreenCapture(object):
             scr.write('')
 
 
-class MockedXWD(object):
+class MockedXWD:
     '''
     Mocked object used instead of the console-like calling
     of X11 xwd binary with parameters.

--- a/plyer/tests/test_storagepath.py
+++ b/plyer/tests/test_storagepath.py
@@ -7,7 +7,6 @@ Tested platforms:
 * macOS
 '''
 
-from __future__ import unicode_literals
 import unittest
 
 from plyer.tests.common import platform_import, PlatformTest

--- a/plyer/tests/test_utils.py
+++ b/plyer/tests/test_utils.py
@@ -138,7 +138,7 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):
+        class Class:
             '''
             Dummy class with deprecated method method.
             '''
@@ -184,7 +184,7 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):
+        class Class:
             '''
             Dummy class with deprecated static method.
             '''
@@ -232,7 +232,7 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):
+        class Class:
             '''
             Dummy class with deprecated static method.
             '''
@@ -284,7 +284,7 @@ class TestUtils(unittest.TestCase):
 
         from plyer.utils import deprecated
 
-        class Class(object):
+        class Class:
             '''
             Dummy class with deprecated class method.
             '''
@@ -326,7 +326,7 @@ class TestUtils(unittest.TestCase):
         from plyer.utils import deprecated
 
         @deprecated
-        class Class(object):
+        class Class:
             '''
             Dummy deprecated class.
             '''
@@ -369,7 +369,7 @@ class TestUtils(unittest.TestCase):
         from plyer.utils import deprecated
 
         @deprecated
-        class Class(object):
+        class Class:
             '''
             Dummy deprecated class.
             '''
@@ -382,7 +382,7 @@ class TestUtils(unittest.TestCase):
             Dummy class inheriting from a dummy deprecated class.
             '''
             def __init__(self, *args, **kwargs):
-                super(Inherited, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
                 self.args = args
                 self.kwargs = kwargs
 

--- a/plyer/tools/pep8checker/pep8.py
+++ b/plyer/tools/pep8checker/pep8.py
@@ -214,7 +214,7 @@ def trailing_whitespace(physical_line):
 
     Okay: spam(1)
     W291: spam(1)\s
-    W293: class Foo(object):\n    \n    bang = 12
+    W293: class Foo:\n    \n    bang = 12
     """
     physical_line = physical_line.rstrip('\n')    # chr(10), newline
     physical_line = physical_line.rstrip('\r')    # chr(13), carriage return
@@ -1155,7 +1155,7 @@ def find_checks(argument_name):
             yield name, codes, function, args
 
 
-class Checker(object):
+class Checker:
     """
     Load a Python source file, tokenize it, check coding style.
     """
@@ -1377,7 +1377,7 @@ class Checker(object):
         return self.report.get_file_results()
 
 
-class BaseReport(object):
+class BaseReport:
     """Collect the results of the checks."""
     print_filename = False
 
@@ -1475,7 +1475,7 @@ class StandardReport(BaseReport):
     """Collect and print the results of the checks."""
 
     def __init__(self, options):
-        super(StandardReport, self).__init__(options)
+        super().__init__(options)
         self._fmt = REPORT_FORMAT.get(options.format.lower(),
                                       options.format)
         self._repeat = options.repeat
@@ -1486,7 +1486,7 @@ class StandardReport(BaseReport):
         """
         Report an error, according to options.
         """
-        code = super(StandardReport, self).error(line_number, offset,
+        code = super().error(line_number, offset,
                                                  text, check)
         if code and (self.counters[code] == 1 or self._repeat):
             print((self._fmt % {
@@ -1510,13 +1510,13 @@ class DiffReport(StandardReport):
     """Collect and print the results for the changed lines only."""
 
     def __init__(self, options):
-        super(DiffReport, self).__init__(options)
+        super().__init__(options)
         self._selected = options.selected_lines
 
     def error(self, line_number, offset, text, check):
         if line_number not in self._selected[self.filename]:
             return
-        return super(DiffReport, self).error(line_number, offset, text, check)
+        return super().error(line_number, offset, text, check)
 
 
 class TestReport(StandardReport):
@@ -1524,7 +1524,7 @@ class TestReport(StandardReport):
 
     def __init__(self, options):
         options.benchmark_keys += ['test cases', 'failed tests']
-        super(TestReport, self).__init__(options)
+        super().__init__(options)
         self._verbose = options.verbose
 
     def get_file_results(self):
@@ -1558,7 +1558,7 @@ class TestReport(StandardReport):
         print(("Test failed." if self.total_errors else "Test passed."))
 
 
-class StyleGuide(object):
+class StyleGuide:
     """Initialize a PEP-8 instance with few options."""
 
     def __init__(self, *args, **kwargs):

--- a/plyer/utils.py
+++ b/plyer/utils.py
@@ -10,7 +10,7 @@ from os import path
 from sys import platform as _sys_platform
 
 
-class Platform(object):
+class Platform:
     '''
     Refactored to class to allow module function to be replaced
     with module variable.
@@ -32,7 +32,7 @@ class Platform(object):
     def __repr__(self):
         return 'platform name: \'{platform}\' from: \n{instance}'.format(
             platform=self._get_platform(),
-            instance=super(Platform, self).__repr__()
+            instance=super().__repr__()
         )
 
     def __hash__(self):
@@ -67,7 +67,7 @@ class Platform(object):
 platform = Platform()
 
 
-class Proxy(object):
+class Proxy:
     '''
     Based on http://code.activestate.com/recipes/496741-object-proxying
     version by Tomer Filiba, PSF license.
@@ -148,7 +148,7 @@ def whereis_exe(program):
     return None
 
 
-class reify(object):
+class reify:
     '''
     Put the result of a method which uses this (non-data) descriptor decorator
     in the instance dict after the first call, effectively replacing the


### PR DESCRIPTION
This is a follow up for:
https://github.com/kivy/plyer/pull/553
- updates `super()` syntax
- removes `object` inheritance
- removes `from __future__ import unicode_literals`