### PR TITLE
filechooser: set _handle_selection as attribute

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -82,19 +82,10 @@ class AndroidFileChooser(FileChooser):
         super().__init__(*args, **kwargs)
         self.select_code = randint(123456, 654321)
         self.selection = None
+        self._handle_selection = None
 
         # bind a function for a response from filechooser activity
         activity.bind(on_activity_result=self._on_activity_result)
-
-    @staticmethod
-    def _handle_selection(selection):
-        '''
-        Dummy placeholder for returning selection from
-        ``android.app.Activity.onActivityResult()``.
-
-        .. versionadded:: 1.4.0
-        '''
-        return selection
 
     def _open_file(self, **kwargs):
         '''
@@ -103,13 +94,7 @@ class AndroidFileChooser(FileChooser):
 
         .. versionadded:: 1.4.0
         '''
-
-        # set up selection handler
-        # startActivityForResult is async
-        # onActivityResult is sync
-        self._handle_selection = kwargs.pop(
-            'on_selection', self._handle_selection
-        )
+        self._handle_selection = kwargs.pop("on_selection")
 
         # create Intent for opening
         file_intent = Intent(Intent.ACTION_GET_CONTENT)

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -40,20 +40,11 @@ class SubprocessFileChooser:
     show_hidden = False
 
     def __init__(self, *args, **kwargs):
-        self._handle_selection = kwargs.pop(
-            'on_selection', self._handle_selection
-        )
+        self._handle_selection = kwargs.pop("on_selection")
 
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
-
-    @staticmethod
-    def _handle_selection(selection):
-        '''
-        Dummy placeholder for returning selection from chooser.
-        '''
-        return selection
 
     _process = None
 

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -38,20 +38,11 @@ class MacFileChooser:
     use_extensions = False
 
     def __init__(self, *args, **kwargs):
-        self._handle_selection = kwargs.pop(
-            'on_selection', self._handle_selection
-        )
+        self._handle_selection = kwargs.pop("on_selection")
 
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
-
-    @staticmethod
-    def _handle_selection(selection):
-        '''
-        Dummy placeholder for returning selection from chooser.
-        '''
-        return selection
 
     def run(self):
         panel = None

--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -43,20 +43,11 @@ class Win32FileChooser:
     show_hidden = False
 
     def __init__(self, *args, **kwargs):
-        self._handle_selection = kwargs.pop(
-            'on_selection', self._handle_selection
-        )
+        self._handle_selection = kwargs.pop("on_selection")
 
         # Simulate Kivy's behavior
         for i in kwargs:
             setattr(self, i, kwargs[i])
-
-    @staticmethod
-    def _handle_selection(selection):
-        '''
-        Dummy placeholder for returning selection from chooser.
-        '''
-        return selection
 
     def run(self):
         self.selection = []


### PR DESCRIPTION
`_handle_selection` was defined as a placeholder for returning the
selection from the activity result. It was used as a fallback when
`on_selection` was not provided.

There's a side effect by doing this: when `on_selection` is not defined,
the `self._handle_selection` attribute overwrites the
`_handle_selection` method. Given that this is a file chooser
implementation, I think it's necessary to have a callback when a file is
chosen by the user. With the current implementation, if the user does
not pass an `on_selection` callback, no error is raised.

The solution is to let `_handle_selection` as an attribute and remove
the static method. This way it is not overwritten and a `KeyError`
exception is raised if `on_selection` is not provided.