### PR TITLE
Some APIs are only available for open panels.

### DIFF
--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -55,22 +55,24 @@ class MacFileChooser:
 
     def run(self):
         panel = None
-        if self.mode in ("open", "dir"):
+        if self.mode in ("open", "dir", "dir_and_files"):
             panel = NSOpenPanel.openPanel()
-        else:
+
+            panel.setCanChooseDirectories_(self.mode != "open")
+            panel.setCanChooseFiles_(self.mode != "dir")
+
+            if self.multiple:
+                panel.setAllowsMultipleSelection_(True)
+        elif self.mode == "save":
             panel = NSSavePanel.savePanel()
+        else:
+            assert False, self.mode
 
         panel.setCanCreateDirectories_(True)
-
-        panel.setCanChooseDirectories_(self.mode == "dir")
-        panel.setCanChooseFiles_(self.mode != "dir")
         panel.setShowsHiddenFiles_(self.show_hidden)
 
         if self.title:
             panel.setTitle_(objc_str(self.title))
-
-        if self.mode != "save" and self.multiple:
-            panel.setAllowsMultipleSelection_(True)
 
         # Mac OS X does not support wildcards unlike the other platforms.
         # This tries to convert wildcards to "extensions" when possible,
@@ -88,6 +90,7 @@ class MacFileChooser:
                     filthies.append(objc_str(pystr))
 
             ftypes_arr = objc_arr(*filthies)
+            # todo: switch to allowedContentTypes
             panel.setAllowedFileTypes_(ftypes_arr)
             panel.setAllowsOtherFileTypes_(not self.use_extensions)
 


### PR DESCRIPTION
I got the following issue from a user on Catalina:

![image](https://user-images.githubusercontent.com/1644286/98168196-34961980-1eb8-11eb-801c-db12cda41331.png)

From https://developer.apple.com/documentation/appkit/nssavepanel and https://developer.apple.com/documentation/appkit/nsopenpanel it seems we have been setting APIs that are only available in the open panel mode even for the save panel mode. This fixes it and move these calls to open mode only (open panel inherits from save panel).