### PR TITLE
Correctly remove missing Bluetooth from matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ implement the api in the easiest way, depending on the current platform.
 | Audio recording                | ✔       |     | ✔       | ✔    |       |
 | Barometer                      | ✔       | ✔   |         |      |       |
 | Battery                        | ✔       | ✔   | ✔       | ✔    | ✔     |
-| Bluetooth                      | ✔       |     |         | ✔    |       |
+| Bluetooth                      |         |     |         |      |       |
 | Brightness                     | ✔       | ✔   |         |      | ✔     |
 | Call                           | ✔       | ✔   |         |      |       |
 | Camera (taking picture)        | ✔       | ✔   |         |      |       |


### PR DESCRIPTION
The support for Bluetooth in the repository is a nonbehaving stub. It shouldn't be marked as supported, as only hardware enabled status is implemented and no communication with devices.
It would be good if a label were added asking for help implementing it.