### PR TITLE
Fix `UnicodeDecodeError` in `Win32FileChooser` class in `run` function

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -136,7 +136,7 @@ class Win32FileChooser:
                 # pidl is None when nothing is selected
                 # and e.g. the dialog is closed afterwards with Cancel
                 if pidl:
-                    self.selection = [str(get_path(pidl).decode('utf-8'))]
+                    self.selection = [str(get_path(pidl).decode('Windows-1251', errors='ignore'))]
 
         except (RuntimeError, pywintypes.error, Exception):
             # ALWAYS! let user know what happened


### PR DESCRIPTION
Previously, when using the Latin alphabet, an error occurred:
```
self.selection = [str(get_path(pidl).decode('utf-8'))]
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0 in position 24: invalid continuation byte
```
So that this error no longer occurs, the encoding was changed to `Windows-1251`, and such errors now do not lead to the termination of the program with an error.