### PR TITLE
Add check for Trinity Desktop Environment

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -241,6 +241,9 @@ class LinuxFileChooser(FileChooser):
     if (str(os.environ.get("XDG_CURRENT_DESKTOP")).lower() == "kde"
             and which("kdialog")):
         desktop = "kde"
+    elif (str(os.environ.get("DESKTOP_SESSION")).lower() == "trinity"
+            and which('kdialog')):
+        desktop = "kde"
     elif which("yad"):
         desktop = "yad"
     elif which("zenity"):


### PR DESCRIPTION
Trinity Desktop Environment is a fork of KDE3 that does not set XDG_CURRENT_DESKTOP but does set DESKTOP_SESSION to `trinity`.

This pr added a check for that.