### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/plyer/facades/accelerometer.py
+++ b/plyer/facades/accelerometer.py
@@ -17,7 +17,7 @@ To enable accelerometer::
     >>> from plyer import accelerometer
     >>> accelerometer.enable()
 
-To disable acceletometer::
+To disable accelerometer::
 
     >>> accelerometer.disable()
 

--- a/plyer/facades/brightness.py
+++ b/plyer/facades/brightness.py
@@ -41,7 +41,7 @@ class Brightness:
     def set_level(self, level):
         '''
         Adjust the brightness of the screen.
-        Minimum brightnesss level:: 1
+        Minimum brightness level:: 1
         Maximum brightness level:: 100
 
         :param level: New level of brightness between 1 and 100

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -37,7 +37,7 @@ class Sms:
         '''
         Send SMS or open SMS interface.
 
-        :param recipient: The reveiver
+        :param recipient: The receiver
         :param message: the message
 
         :type recipient: number

--- a/plyer/facades/wifi.py
+++ b/plyer/facades/wifi.py
@@ -119,7 +119,7 @@ class Wifi:
 
     def get_network_info(self, name):
         '''
-        Return a dictionary of secified network.
+        Return a dictionary of specified network.
         '''
         return self._get_network_info(name=name)
 

--- a/plyer/platforms/ios/camera.py
+++ b/plyer/platforms/ios/camera.py
@@ -29,7 +29,7 @@ class iOSCamera(Camera):
         return True
 
     def capture_callback(self, photolibrary):
-        # Image was choosen
+        # Image was chosen
 
         # unbind
         self.photos.unbind(on_image_captured=self.capture_callback)

--- a/plyer/platforms/ios/filechooser.py
+++ b/plyer/platforms/ios/filechooser.py
@@ -63,7 +63,7 @@ class IOSFileChooser(FileChooser):
     def imagePickerController_didFinishPickingMediaWithInfo_(
             self, image_picker, frozen_dict):
         """
-        Delegate which handles the result of the image seletion process.
+        Delegate which handles the result of the image selection process.
         """
         image_picker.dismissViewControllerAnimated_completion_(True, None)
 

--- a/plyer/platforms/ios/sms.py
+++ b/plyer/platforms/ios/sms.py
@@ -23,7 +23,7 @@ class IOSSms(Sms):
             - recipient: String type
             - message: String type
 
-        Opens a mesage interface with recipient and message information.
+        Opens a message interface with recipient and message information.
         '''
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')

--- a/plyer/platforms/ios/vibrator.py
+++ b/plyer/platforms/ios/vibrator.py
@@ -11,7 +11,7 @@ class IosVibrator(Vibrator):
     '''iOS Vibrator class.
 
     iOS doesn't support any feature.
-    All time, pattern, repeatition are ignored.
+    All time, pattern, repetition are ignored.
     '''
 
     def __init__(self):


### PR DESCRIPTION
There are small typos in:
- plyer/facades/accelerometer.py
- plyer/facades/brightness.py
- plyer/facades/sms.py
- plyer/facades/wifi.py
- plyer/platforms/ios/camera.py
- plyer/platforms/ios/filechooser.py
- plyer/platforms/ios/sms.py
- plyer/platforms/ios/vibrator.py

Fixes:
- Should read `specified` rather than `secified`.
- Should read `selection` rather than `seletion`.
- Should read `repetition` rather than `repeatition`.
- Should read `receiver` rather than `reveiver`.
- Should read `message` rather than `mesage`.
- Should read `chosen` rather than `choosen`.
- Should read `brightness` rather than `brightnesss`.
- Should read `accelerometer` rather than `acceletometer`.

Closes #622