### PR TITLE
Support to get android device name or hostname for linux and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ implement the api in the easiest way, depending on the current platform.
 | Camera (taking picture)        | ✔       | ✔   |         |      |       |
 | Compass                        | ✔       | ✔   |         |      |       |
 | CPU count                      |         |     | ✔       | ✔    | ✔     |
-| Devicename                     | ✔       |     | ✔       |      | ✔     |
+| Devicename                     | ✔       |     | ✔       | ✔    | ✔     |
 | Email (open mail client)       | ✔       | ✔   | ✔       | ✔    | ✔     |
 | Flash                          | ✔       | ✔   |         |      |       |
 | GPS                            | ✔       | ✔   |         |      |       |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ implement the api in the easiest way, depending on the current platform.
 | Camera (taking picture)        | ✔       | ✔   |         |      |       |
 | Compass                        | ✔       | ✔   |         |      |       |
 | CPU count                      |         |     | ✔       | ✔    | ✔     |
+| Devicename                     | ✔       |     | ✔       |      | ✔     |
 | Email (open mail client)       | ✔       | ✔   | ✔       | ✔    | ✔     |
 | Flash                          | ✔       | ✔   |         |      |       |
 | GPS                            | ✔       | ✔   |         |      |       |
@@ -58,6 +59,7 @@ implement the api in the easiest way, depending on the current platform.
 | Unique ID                      | ✔       | ✔   | ✔       | ✔    | ✔     |
 | Vibrator                       | ✔       | ✔   |         |      |       |
 | Wifi                           |         |     | ✔       | ✔    | ✔     |
+
 
 ## Installation
 

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -10,7 +10,7 @@ __all__ = (
     'flash', 'gps', 'gravity', 'gyroscope', 'humidity', 'irblaster',
     'keystore', 'light', 'notification', 'orientation', 'processors',
     'proximity', 'screenshot', 'sms', 'spatialorientation', 'storagepath',
-    'stt', 'temperature', 'tts', 'uniqueid', 'vibrator', 'wifi'
+    'stt', 'temperature', 'tts', 'uniqueid', 'vibrator', 'wifi', 'devicename'
 )
 
 __version__ = '2.0.1.dev0'
@@ -119,3 +119,6 @@ cpu = Proxy('cpu', facades.CPU)
 
 #: Screenshot proxy to :class:`plyer.facades.Screenshot`
 screenshot = Proxy('screenshot', facades.Screenshot)
+
+#: devicename proxy to :class:`plyer.facades.DeviceName`
+devicename = Proxy('devicename', facades.DeviceName)

--- a/plyer/__init__.py
+++ b/plyer/__init__.py
@@ -13,7 +13,7 @@ __all__ = (
     'stt', 'temperature', 'tts', 'uniqueid', 'vibrator', 'wifi', 'devicename'
 )
 
-__version__ = '2.0.1.dev0'
+__version__ = '2.1.0.dev0'
 
 
 from plyer import facades

--- a/plyer/facades/__init__.py
+++ b/plyer/facades/__init__.py
@@ -12,7 +12,7 @@ __all__ = ('Accelerometer', 'Audio', 'Barometer', 'Battery', 'Call', 'Camera',
            'Sms', 'TTS', 'UniqueID', 'Vibrator', 'Wifi', 'Flash', 'CPU',
            'Temperature', 'Humidity', 'SpatialOrientation', 'Brightness',
            'Processors', 'StoragePath', 'Keystore', 'Bluetooth', 'Screenshot',
-           'STT')
+           'STT', 'DeviceName')
 
 from plyer.facades.accelerometer import Accelerometer
 from plyer.facades.audio import Audio
@@ -48,3 +48,4 @@ from plyer.facades.bluetooth import Bluetooth
 from plyer.facades.processors import Processors
 from plyer.facades.cpu import CPU
 from plyer.facades.screenshot import Screenshot
+from plyer.facades.devicename import DeviceName

--- a/plyer/facades/devicename.py
+++ b/plyer/facades/devicename.py
@@ -1,0 +1,50 @@
+'''DeviceName facade.
+
+Returns the following depending on the platform:
+
+* **Android**: Android Device name
+* **Linux**: Hostname of the machine
+* **Windows**: Hostname of the machine
+
+Simple Example
+--------------
+
+To get the unique ID::
+
+    >>> from plyer import devicename
+    >>> devicename.device_name
+    'Oneplus 3'
+
+.. versionadded:: 2.0.0
+    - first release
+
+
+Supported Platforms
+-------------------
+Android, Windows, Linux
+
+'''
+
+
+class DeviceName:
+    '''
+    DeviceName facade.
+    '''
+
+    @property
+    def device_name(self):
+        '''
+        Property that returns the device name of the platform.
+        '''
+        return self.get_device_name()
+
+    def get_device_name(self):
+        '''
+        Public method for getting device name via platform-specific
+        API in plyer.platforms.
+        '''
+        return self._get_device_name()
+
+    # private
+    def _get_device_name(self):
+        raise NotImplementedError()

--- a/plyer/facades/devicename.py
+++ b/plyer/facades/devicename.py
@@ -15,7 +15,7 @@ To get the unique ID::
     >>> devicename.device_name
     'Oneplus 3'
 
-.. versionadded:: 2.0.0
+.. versionadded:: 2.1.0
     - first release
 
 
@@ -35,13 +35,6 @@ class DeviceName:
     def device_name(self):
         '''
         Property that returns the device name of the platform.
-        '''
-        return self.get_device_name()
-
-    def get_device_name(self):
-        '''
-        Public method for getting device name via platform-specific
-        API in plyer.platforms.
         '''
         return self._get_device_name()
 

--- a/plyer/facades/devicename.py
+++ b/plyer/facades/devicename.py
@@ -4,6 +4,7 @@ Returns the following depending on the platform:
 
 * **Android**: Android Device name
 * **Linux**: Hostname of the machine
+* **OS X**: Hostname of the machine
 * **Windows**: Hostname of the machine
 
 Simple Example
@@ -21,7 +22,7 @@ To get the unique ID::
 
 Supported Platforms
 -------------------
-Android, Windows, Linux
+Android, Windows, OS X, Linux
 
 '''
 

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -14,7 +14,7 @@ class AndroidDeviceName(UniqueID):
     Implementation of Android devicename API.
     '''
 
-    def _get_uid(self):
+    def _get_device_name(self):
         return Secure.getString(
             activity.getContentResolver(),
             Secure.DEVICE_NAME

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -1,0 +1,28 @@
+'''
+Module of Android API for plyer.devicename.
+'''
+
+from jnius import autoclass
+from plyer.platforms.android import activity
+from plyer.facades import UniqueID
+
+Secure = autoclass('android.provider.Global$Secure')
+
+
+class AndroidDeviceName(UniqueID):
+    '''
+    Implementation of Android devicename API.
+    '''
+
+    def _get_uid(self):
+        return Secure.getString(
+            activity.getContentResolver(),
+            Secure.DEVICE_NAME
+        )
+
+
+def instance():
+    '''
+    Instance for facade proxy.
+    '''
+    return AndroidDeviceName()

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -4,12 +4,12 @@ Module of Android API for plyer.devicename.
 
 from jnius import autoclass
 from plyer.platforms.android import activity
-from plyer.facades import UniqueID
+from plyer.facades import DeviceName
 
 Secure = autoclass('android.provider.Global$Secure')
 
 
-class AndroidDeviceName(UniqueID):
+class AndroidDeviceName(DeviceName):
     '''
     Implementation of Android devicename API.
     '''

--- a/plyer/platforms/linux/devicename.py
+++ b/plyer/platforms/linux/devicename.py
@@ -12,9 +12,7 @@ class LinuxDeviceName(DeviceName):
     '''
 
     def _get_device_name(self):
-        hostname = None
-        if not socket.gethostname():
-            hostname = socket.gethostname()
+        hostname = socket.gethostname()
         return hostname
 
 

--- a/plyer/platforms/linux/devicename.py
+++ b/plyer/platforms/linux/devicename.py
@@ -5,6 +5,7 @@ Module of Linux API for plyer.devicename.
 import socket
 from plyer.facades import DeviceName
 
+
 class LinuxDeviceName(DeviceName):
     '''
     Implementation of Linux DeviceName API.
@@ -12,11 +13,10 @@ class LinuxDeviceName(DeviceName):
 
     def _get_device_name(self):
         hostname = None
-        
         if not socket.gethostname():
             hostname = socket.gethostname()
-            
         return hostname
+
 
 def instance():
     '''

--- a/plyer/platforms/linux/devicename.py
+++ b/plyer/platforms/linux/devicename.py
@@ -1,0 +1,25 @@
+'''
+Module of Linux API for plyer.devicename.
+'''
+
+import socket
+from plyer.facades import DeviceName
+
+class LinuxDeviceName(DeviceName):
+    '''
+    Implementation of Linux DeviceName API.
+    '''
+
+    def _get_device_name(self):
+        hostname = None
+        
+        if not socket.gethostname():
+            hostname = socket.gethostname()
+            
+        return hostname
+
+def instance():
+    '''
+    Instance for facade proxy.
+    '''
+    return LinuxDeviceName()

--- a/plyer/platforms/macosx/devicename.py
+++ b/plyer/platforms/macosx/devicename.py
@@ -1,0 +1,23 @@
+'''
+Module of MacOSX API for plyer.devicename.
+'''
+
+import socket
+from plyer.facades import DeviceName
+
+
+class OSXDeviceName(DeviceName):
+    '''
+    Implementation of MacOSX DeviceName API.
+    '''
+
+    def _get_device_name(self):
+        hostname = socket.gethostname()
+        return hostname
+
+
+def instance():
+    '''
+    Instance for facade proxy.
+    '''
+    return OSXDeviceName()

--- a/plyer/platforms/win/devicename.py
+++ b/plyer/platforms/win/devicename.py
@@ -1,0 +1,25 @@
+'''
+Module of Win API for plyer.devicename.
+'''
+
+import socket
+from plyer.facades import DeviceName
+
+class WinDeviceName(DeviceName):
+    '''
+    Implementation of Linux DeviceName API.
+    '''
+
+    def _get_device_name(self):
+        hostname = None
+        
+        if not socket.gethostname():
+            hostname = socket.gethostname()
+            
+        return hostname
+
+def instance():
+    '''
+    Instance for facade proxy.
+    '''
+    return WinDeviceName()

--- a/plyer/platforms/win/devicename.py
+++ b/plyer/platforms/win/devicename.py
@@ -5,6 +5,7 @@ Module of Win API for plyer.devicename.
 import socket
 from plyer.facades import DeviceName
 
+
 class WinDeviceName(DeviceName):
     '''
     Implementation of Linux DeviceName API.
@@ -12,11 +13,10 @@ class WinDeviceName(DeviceName):
 
     def _get_device_name(self):
         hostname = None
-        
         if not socket.gethostname():
             hostname = socket.gethostname()
-            
         return hostname
+
 
 def instance():
     '''

--- a/plyer/platforms/win/devicename.py
+++ b/plyer/platforms/win/devicename.py
@@ -12,9 +12,7 @@ class WinDeviceName(DeviceName):
     '''
 
     def _get_device_name(self):
-        hostname = None
-        if not socket.gethostname():
-            hostname = socket.gethostname()
+        hostname = socket.gethostname()
         return hostname
 
 

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -12,6 +12,7 @@ from mock import patch, Mock
 from plyer.tests.common import PlatformTest, platform_import
 import socket
 
+
 class TestDeviceName(unittest.TestCase):
     '''
     TestCase for plyer.devicename.
@@ -33,11 +34,13 @@ class TestDeviceName(unittest.TestCase):
             platform='Win',
             module_name='devicename',
         )
-        
-        with patch.object(socket, 'gethostname', return_value='mocked_hostname') as mock_method:
+        with patch.object(socket,
+                          'gethostname',
+                          return_value='mocked_hostname'
+                          ) as mock_method:
             evaluated_device_name = devicename.device_name
             self.assertEqual(evaluated_device_name, 'mocked_hostname')
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -31,7 +31,7 @@ class TestDeviceName(unittest.TestCase):
         with patch.object(socket,
                           'gethostname',
                           return_value='mocked_windows_hostname'
-                          ) as mock_method:
+                          ) as _:
 
             evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_windows_hostname')
@@ -49,7 +49,7 @@ class TestDeviceName(unittest.TestCase):
         with patch.object(socket,
                           'gethostname',
                           return_value='mocked_linux_hostname'
-                          ) as mock_method:
+                          ) as _:
 
             evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_linux_hostname')
@@ -67,7 +67,7 @@ class TestDeviceName(unittest.TestCase):
         with patch.object(socket,
                           'gethostname',
                           return_value='mocked_macosx_hostname'
-                          ) as mock_method:
+                          ) as _:
 
             evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_macosx_hostname')

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -33,7 +33,7 @@ class TestDeviceName(unittest.TestCase):
                           return_value='mocked_windows_hostname'
                           ) as mock_method:
 
-            evaluated_device_name = devicename_instance._get_device_name()
+            evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_windows_hostname')
 
     @PlatformTest('linux')
@@ -51,7 +51,7 @@ class TestDeviceName(unittest.TestCase):
                           return_value='mocked_linux_hostname'
                           ) as mock_method:
 
-            evaluated_device_name = devicename_instance._get_device_name()
+            evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_linux_hostname')
 
 

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -8,7 +8,7 @@ Tested platforms:
 '''
 
 import unittest
-from mock import patch, Mock
+from mock import patch
 from plyer.tests.common import PlatformTest, platform_import
 import socket
 
@@ -18,28 +18,41 @@ class TestDeviceName(unittest.TestCase):
     TestCase for plyer.devicename.
     '''
 
-    def test_devicename(self):
-        '''
-        General all platform test for plyer.devicename.
-        '''
-        from plyer import devicename
-        self.assertTrue(len(devicename.device_name) > 0)
-
     @PlatformTest('win')
     def test_devicename_win(self):
         '''
         Test Windows API for plyer.devicename.
         '''
-        devicename = platform_import(
-            platform='Win',
-            module_name='devicename',
-        )
+        devicename = platform_import(platform='win',
+                                     module_name='devicename'
+                                     )
+        devicename_instance = devicename.instance()
+
         with patch.object(socket,
                           'gethostname',
-                          return_value='mocked_hostname'
+                          return_value='mocked_windows_hostname'
                           ) as mock_method:
-            evaluated_device_name = devicename.device_name
-            self.assertEqual(evaluated_device_name, 'mocked_hostname')
+
+            evaluated_device_name = devicename_instance._get_device_name()
+            self.assertEqual(evaluated_device_name, 'mocked_windows_hostname')
+
+    @PlatformTest('linux')
+    def test_devicename_linux(self):
+        '''
+        Test Linux API for plyer.devicename.
+        '''
+        devicename = platform_import(platform='linux',
+                                     module_name='devicename'
+                                     )
+        devicename_instance = devicename.instance()
+
+        with patch.object(socket,
+                          'gethostname',
+                          return_value='mocked_linux_hostname'
+                          ) as mock_method:
+
+            evaluated_device_name = devicename_instance._get_device_name()
+            self.assertEqual(evaluated_device_name, 'mocked_linux_hostname')
 
 
 if __name__ == '__main__':

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -1,0 +1,43 @@
+'''
+TestDeviceName
+============
+
+Tested platforms:
+
+* Windows
+'''
+
+import unittest
+from mock import patch, Mock
+from plyer.tests.common import PlatformTest, platform_import
+import socket
+
+class TestDeviceName(unittest.TestCase):
+    '''
+    TestCase for plyer.devicename.
+    '''
+
+    def test_devicename(self):
+        '''
+        General all platform test for plyer.devicename.
+        '''
+        from plyer import devicename
+        self.assertTrue(len(devicename.device_name) > 0)
+
+    @PlatformTest('win')
+    def test_devicename_win(self):
+        '''
+        Test Windows API for plyer.devicename.
+        '''
+        devicename = platform_import(
+            platform='Win',
+            module_name='devicename',
+        )
+        
+        with patch.object(socket, 'gethostname', return_value='mocked_hostname') as mock_method:
+            evaluated_device_name = devicename.device_name
+            self.assertEqual(evaluated_device_name, 'mocked_hostname')
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -54,6 +54,24 @@ class TestDeviceName(unittest.TestCase):
             evaluated_device_name = devicename_instance.device_name
             self.assertEqual(evaluated_device_name, 'mocked_linux_hostname')
 
+    @PlatformTest('macosx')
+    def test_devicename_macosx(self):
+        '''
+        Test MacOSX API for plyer.devicename.
+        '''
+        devicename = platform_import(platform='macosx',
+                                     module_name='devicename'
+                                     )
+        devicename_instance = devicename.instance()
+
+        with patch.object(socket,
+                          'gethostname',
+                          return_value='mocked_macosx_hostname'
+                          ) as mock_method:
+
+            evaluated_device_name = devicename_instance.device_name
+            self.assertEqual(evaluated_device_name, 'mocked_macosx_hostname')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This support is for adding a new feature (`plyer.devicename`) which will allow user to get the device name in case of an android  device.
This is also supported for linux and windows where it will return the hostname of the environment.

I also wanted to added support for ios ; but I don't have environment to test those.

Please review this PR.

PS: testing screenshot attached for windows and linux
Validated the functionality of socket.gethostname in MacOSX and added its support as well.

![image_2021-06-19_150212](https://user-images.githubusercontent.com/4651919/122638034-54a8df00-d10f-11eb-89b9-9918981d6741.png)
![image_2021-06-19_150219](https://user-images.githubusercontent.com/4651919/122638036-583c6600-d10f-11eb-96ad-edfff48fe975.png)
