### PR TITLE
Removed python2.6|7 reference and added reference for python 3.6|7|8 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,12 +74,13 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     **EXTRA_OPTIONS
 )


### PR DESCRIPTION
Fixes #608 
Removed reference of Python 2.6 and 2.7 in setup.py file
Also added reference for Python 3.6, 3.7 and 3.8 in setup.py file