### PR TITLE
Added contributors in readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ IRC channel:
 Plyer is released under the terms of the MIT License. Please refer to the
 LICENSE file.
 
+## Contributors
+
+This project exists thanks to all the people who contribute. [[Contribute](http://kivy.org/docs/contribute.html)].
+
+<a href="https://github.com/kivy/plyer/graphs/contributors"><img src="https://contrib.rocks/image?repo=kivy/plyer"/></a>
 
 ## Backers
 


### PR DESCRIPTION
Just an enhancement in the README.MD file.
This PR adds support to display badges of all the valuable contributors of this repo.

Here's how it looks ?

![image_2021-06-21_111759](https://user-images.githubusercontent.com/4651919/122712867-57781100-d282-11eb-9ed8-0176893c4280.png)

