### PR TITLE
updated-device-name-implementation-for-backward-compatibility

### DIFF
--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -15,7 +15,7 @@ class AndroidDeviceName(DeviceName):
 
     def _get_device_name(self):
         """
-        Method to get the device name in an android environment.
+        Method to get the device name aka model in an android environment.
 
         Changed the implementation from 'android.provider.Settings.Global' to
         'android.os.Build' becuase 'android.provider.Settings.Global' was
@@ -23,7 +23,7 @@ class AndroidDeviceName(DeviceName):
 
         Thereby making this method more backward compatible.
         """
-        return Build.DEVICE
+        return Build.MODEL
 
 
 def instance():

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -3,10 +3,9 @@ Module of Android API for plyer.devicename.
 '''
 
 from jnius import autoclass
-from plyer.platforms.android import activity
 from plyer.facades import DeviceName
 
-Secure = autoclass('android.provider.Global$Secure')
+Build = autoclass('android.os.Build')
 
 
 class AndroidDeviceName(DeviceName):
@@ -15,10 +14,16 @@ class AndroidDeviceName(DeviceName):
     '''
 
     def _get_device_name(self):
-        return Secure.getString(
-            activity.getContentResolver(),
-            Secure.DEVICE_NAME
-        )
+        """
+        Method to get the device name in an android environment.
+
+        Changed the implementation from 'android.provider.Settings.Global' to
+        'android.os.Build' becuase 'android.provider.Settings.Global' was
+        introduced in API 17 whereas 'android.os.Build' is present since API 1
+
+        Thereby making this method more backward compatible.
+        """
+        return Build.DEVICE
 
 
 def instance():

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -18,7 +18,7 @@ class AndroidDeviceName(DeviceName):
         Method to get the device name aka model in an android environment.
 
         Changed the implementation from 'android.provider.Settings.Global' to
-        'android.os.Build' becuase 'android.provider.Settings.Global' was
+        'android.os.Build' because 'android.provider.Settings.Global' was
         introduced in API 17 whereas 'android.os.Build' is present since API 1
 
         Thereby making this method more backward compatible.


### PR DESCRIPTION
Updated the previous `devicename` implementation for android.

Previous implementation was limited to API 17, updated the implementation so this this functionality works with API 1 as well.