### PR TITLE
Allow transient notifications on Linux

### DIFF
--- a/plyer/facades/notification.py
+++ b/plyer/facades/notification.py
@@ -46,7 +46,7 @@ class Notification:
     '''
 
     def notify(self, title='', message='', app_name='', app_icon='',
-               timeout=10, ticker='', toast=False):
+               timeout=10, ticker='', toast=False, **kwargs):
         '''
         Send a notification.
 
@@ -79,7 +79,7 @@ class Notification:
         self._notify(
             title=title, message=message,
             app_icon=app_icon, app_name=app_name,
-            timeout=timeout, ticker=ticker, toast=toast
+            timeout=timeout, ticker=ticker, toast=toast, **kwargs
         )
 
     # private

--- a/plyer/platforms/linux/notification.py
+++ b/plyer/platforms/linux/notification.py
@@ -14,9 +14,25 @@ class NotifySendNotification(Notification):
     using notify-send binary.
     '''
     def _notify(self, **kwargs):
-        subprocess.call([
-            "notify-send", kwargs.get('title'), kwargs.get('message')
-        ])
+        icon = kwargs.get('icon', '')
+        title = kwargs.get('title', 'title')
+        hint = kwargs.get('hint', 'string::')
+        message = kwargs.get('message', 'body')
+        category = kwargs.get('category', '')
+        app_name = kwargs.get('app_name', '')
+        urgency = kwargs.get('urgency', 'normal')
+        expire_time = kwargs.get('expire_time', '0')
+
+        notify_send_args = (title, 
+                            message, 
+                            "-i", icon, 
+                            "-h", hint,
+                            "-u", urgency, 
+                            "-c", category, 
+                            "-a", app_name,
+                            "-t", expire_time)
+
+        subprocess.call(["notify-send", *notify_send_args])
 
 
 class NotifyDbus(Notification):


### PR DESCRIPTION
Hello!

Transient notifications (notifications that don't persist in the notifications list) are not programmable on Linux, even though they can be. The reason is because the `hints` parameter required by `notify-send` and `dbus` can not passed to the base [`Notification.notify()`](https://github.com/kivy/plyer/blob/0c226e1fbc2f70d713654aa6443488d71b31af93/plyer/facades/notification.py#L48) method. 

I've implemented a simple solution that allows the other keyword arguments to be passed to the `notify()` method, allowing the underlying `_notify()` implementation to use `hints` and other notification arguments as required.


Currently, trying to use hints with the `notify()` call fails: 
```
>>> from plyer import notification
>>> print(notification)
<plyer.platforms.linux.notification.NotifyDbus object at 0x7f72cb4d4040>
>>> notification.notify(title="Hello", message="World", hints={'transient':1})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: notify() got an unexpected keyword argument 'hints'
```

... even though, the underlying `NotifyDBus` implementation clearly supports it:
https://github.com/kivy/plyer/blob/0c226e1fbc2f70d713654aa6443488d71b31af93/plyer/platforms/linux/notification.py#L35

With these changes, the transient notifications work as expected.
```
>>> from plyer import notification
>>> print(notification)
<plyer.platforms.linux.notification.NotifyDbus object at 0x7f39fd5ed520>
>>> notification.notify(title="Hello", message="World", hints={'transient':1})
>>> 
```

The `notify-send` implementation also did not support other arguments other than the `title` and the `message`. I've added support for `hints`, `urgency`, etc., as supported by the `notify-send` binary itself:

```
❯ notify-send --help
Usage:
  notify-send [OPTION…] <SUMMARY> [BODY] - create a notification

Help Options:
  -?, --help                        Show help options

Application Options:
  -u, --urgency=LEVEL               Specifies the urgency level (low, normal, critical).
  -t, --expire-time=TIME            Specifies the timeout in milliseconds at which to expire the notification.
  -a, --app-name=APP_NAME           Specifies the app name for the icon
  -i, --icon=ICON[,ICON...]         Specifies an icon filename or stock icon to display.
  -c, --category=TYPE[,TYPE...]     Specifies the notification category.
  -h, --hint=TYPE:NAME:VALUE        Specifies basic extra data to pass. Valid types are int, double, string and byte.
  -v, --version                     Version of the package.
```


