### PR TITLE
Change `PythonActivity` java class

### DIFF
--- a/plyer/platforms/android/camera.py
+++ b/plyer/platforms/android/camera.py
@@ -6,7 +6,7 @@ from plyer.facades import Camera
 from plyer.platforms.android import activity
 
 Intent = autoclass('android.content.Intent')
-PythonActivity = autoclass('org.renpy.android.PythonActivity')
+PythonActivity = autoclass('org.kivy.android.PythonActivity')
 MediaStore = autoclass('android.provider.MediaStore')
 Uri = autoclass('android.net.Uri')
 


### PR DESCRIPTION
As far as I know `org.renpy.android.PythonActivity` depracted, preferably and correctly used `org.kivy.android.PythonActivity`