### PR TITLE
linux/storagepath: fixup a host of issues

### DIFF
--- a/plyer/platforms/linux/storagepath.py
+++ b/plyer/platforms/linux/storagepath.py
@@ -44,7 +44,7 @@ class LinuxStoragePath(StoragePath):
         return "/"
 
     def _get_documents_dir(self):
-        directory = self._get_from_user_dirs("DOCUMENT")
+        directory = self._get_from_user_dirs("DOCUMENTS")
         return directory.replace("$HOME", self._get_home_dir())
 
     def _get_downloads_dir(self):

--- a/plyer/platforms/linux/storagepath.py
+++ b/plyer/platforms/linux/storagepath.py
@@ -4,35 +4,36 @@ Linux Storage Path
 '''
 
 from plyer.facades import StoragePath
-from os.path import expanduser, dirname, abspath
+from os.path import expanduser, dirname, abspath, join, exists
 
 # Default paths for each name
 USER_DIRS = "/.config/user-dirs.dirs"
 
 PATHS = {
-    "DESKTOP": "/Desktop",
-    "DOCUMENTS": "/Documents",
-    "DOWNLOAD": "/Downloads",
-    "MUSIC": "/Music",
-    "PICTURES": "/Pictures",
-    "VIDEOS": "/Videos"
+    "DESKTOP": "Desktop",
+    "DOCUMENTS": "Documents",
+    "DOWNLOAD": "Downloads",
+    "MUSIC": "Music",
+    "PICTURES": "Pictures",
+    "VIDEOS": "Videos"
 }
 
 
 class LinuxStoragePath(StoragePath):
 
     def _get_from_user_dirs(self, name):
-        try:
-            with open(self._get_home_dir() + USER_DIRS, "r") as f:
-                lines = f.readlines()
-                # Find the line that starts with XDG_<name> to get the path
-                index = [i for i, v in enumerate(lines)
-                         if v.startswith("XDG_" + name)][0]
-                return lines[index].split('"')[1]
-        except KeyError:
-            return PATHS[name]
-        except Exception as e:
-            raise e
+        home_dir = self._get_home_dir()
+        default = join(home_dir, PATHS[name])
+        user_dirs = join(home_dir, USER_DIRS)
+        if not exists(user_dirs):
+            return default
+
+        with open(user_dirs, "r") as f:
+            for l in f.readlines():
+                if l.startswith("XDG_" + name):
+                    return l.split('"')[1]
+
+        return default
 
     def _get_home_dir(self):
         return expanduser('~')


### PR DESCRIPTION
The issues fixed are explained in the commits:

Author: Romanos Skiadas <rom.skiad@gmail.com>
Date:   Fri Sep 17 20:41:42 2021 +0300

    linux/storagepath: Revamp handling of user-dirs
    
    - dont assume that ~/.config/user-dirs.dirs exists
    - don't assume it does have contents or the relevant value
    - don't use exception handling as happy path control flow
    - when defaulting, use the path under HOME, not e.g. /Pictures

commit 99dabb2d62248fc3ea5705c2720abf71c9fc378b
Author: Romanos Skiadas <rom.skiad@gmail.com>
Date:   Fri Sep 17 20:31:08 2021 +0300

    linux/storagepath: Fixup DOCUMENTS to DOCUMENT
    
    this is the right name according to the XDG spec, and the key used in
    the default paths dict

This is a superset of https://github.com/kivy/plyer/pull/539. It both fixes more issues, and makes the code a bit simpler, as it removes the exception handling that is not really needed. The reaason for this PR is that the other PR seems to have stalled, and we would like to merge these fixes in order to package plyer for nixpkgs, as it's a dependency of a new version of mirage, which is already packaged.