### PR TITLE
Change R$drawable to R$mipmap in notification.py for android platform

### DIFF
--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -26,7 +26,7 @@ AndroidString = autoclass('java.lang.String')
 Context = autoclass('android.content.Context')
 NotificationBuilder = autoclass('android.app.Notification$Builder')
 NotificationManager = autoclass('android.app.NotificationManager')
-Drawable = autoclass("{}.R$drawable".format(activity.getPackageName()))
+Drawable = autoclass("{}.R$mipmap".format(activity.getPackageName()))
 PendingIntent = autoclass('android.app.PendingIntent')
 Intent = autoclass('android.content.Intent')
 Toast = autoclass('android.widget.Toast')
@@ -97,7 +97,7 @@ class AndroidNotification(Notification):
 
         .. versionadded:: 1.4.0
         '''
-        app_icon = Drawable.presplash
+        app_icon = Drawable.icon
         notification.setSmallIcon(app_icon)
 
         bitmap_icon = app_icon


### PR DESCRIPTION
### Changing Drawable.icon to Drawable.presplash in line 100 of notification.py

Fixed for issue `Notificaiton for android not working [Drawable.icon ]` #647  