### PR TITLE
Make AndroidCamera compatible with android API >= 24

### DIFF
--- a/plyer/platforms/android/camera.py
+++ b/plyer/platforms/android/camera.py
@@ -64,21 +64,21 @@ class AndroidCamera(Camera):
             return Uri.parse('file://' + filename)
         #
         # For Android >= 10, we need to declare a FileProvider in
-        # AndroidManifest and set plyer.camera.FILEPROVIDER_AUTHORITY accordingly
-        currentActivity = cast('android.app.Activity', PythonActivity.mActivity)
-        ctx = currentActivity.getApplicationContext()
+        # AndroidManifest and set plyer.camera.FILEPROVIDER_AUTHORITY
+        # accordingly
+        curActivity = cast('android.app.Activity', PythonActivity.mActivity)
+        ctx = curActivity.getApplicationContext()
         try:
             return FileProvider.getUriForFile(ctx, self.FILEPROVIDER_AUTHORITY,
                                               File(filename))
-        except JavaException as exc:
+        except JavaException:
             raise Exception(
-                f'Cannot get a uri for filename {filename} for the Fileprovider '
-                f'authority {self.FILEPROVIDER_AUTHORITY}.  This probably means that '
-                f'FILE_PROVIDER_PATHS is not configured correctly in '
-                f'AndroidManifest.xml and/or you need to change the value of '
-                f'plyer.camera.FILEPROVIDER_AUTHORITY'
+                f'Cannot get a uri for filename {filename} for the '
+                f'Fileprovider authority {self.FILEPROVIDER_AUTHORITY}.  This '
+                f'probably means that FILE_PROVIDER_PATHS is not configured '
+                f'correctly in AndroidManifest.xml and/or you need to change '
+                f'the value of plyer.camera.FILEPROVIDER_AUTHORITY'
             )
-        return uri
 
 
 def instance():


### PR DESCRIPTION
This should finally fix #500 .

On modern android versions, the only way use the `ACTION_IMAGE_CAPTURE` intent is to use fileproviders, and somehow we need to tell `plyer` which fileprovider authority to use. I don't think there is a general mechanism to configure per-platform settings in plyer, so in the PR I adopted for the following API:

```python
from kivy.utils import platform
import plyer
if platform == 'android':
    plyer.camera.FILEPROVIDER_AUTHORITY = '...'
plyer.camera.take_picture(filename, ...)
```

This works as long as `filename` has a proper configured fileprovider, which is not possible with the current `p4a` version.
The easiest way is to use https://github.com/kivy/python-for-android/pull/1922.

I also published a fully working example which combines this PR, https://github.com/kivy/python-for-android/pull/1922 and https://github.com/kivy/buildozer/pull/1369:
https://github.com/antocuni/plyer_camera_example