### PR TITLE
fix: fix filechooser save dialog for the KDE

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -158,7 +158,7 @@ class KDialogFileChooser(SubprocessFileChooser):
             ]
         elif self.mode == "save":
             cmdline += [
-                "--getopenfilename",
+                "--getsavefilename",
                 (self.path if self.path else os.path.expanduser("~")),
                 " ".join(filt)
             ]


### PR DESCRIPTION
This PR resolves the issue that occurs on the KDE-based Linux distributions. 
The wrong flag was used. the right one is  
` --getsavefilename                 File dialog to save a file (arguments
                                    [startDir] [filter])
`