### PR TITLE
Bigger buffer, allows large selection

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -76,6 +76,10 @@ class Win32FileChooser:
                 args["Title"] = self.title if self.title else "Pick a file..."
                 args["CustomFilter"] = 'Other file types\x00*.*\x00'
                 args["FilterIndex"] = 1
+                file = ""
+                if "File" in args:
+                    file = args["File"]
+                args["File"] = file + ("\x00"*4096)
 
                 # e.g. open_file(filters=['*.txt', '*.py'])
                 filters = ""


### PR DESCRIPTION
Fixes Crash due to low buffer for selecting large number of files > 100
Ref: https://mail.python.org/pipermail/python-win32/2018-June/014071.html