### PR TITLE
Fix bug, when user canceled filechooser, `on_selection` does not dispatched

### DIFF
--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -98,17 +98,14 @@ class MacFileChooser:
             url = NSURL.fileURLWithPath_(self.path)
             panel.setDirectoryURL_(url)
 
-        selection = ['']
+        selection = None
 
         if panel.runModal():
             if self.mode == "save" or not self.multiple:
                 selection = [panel.filename().UTF8String()]
             else:
                 filename = panel.filenames()
-                selection = [
-                    filename.objectAtIndex_(x).UTF8String()
-                    for x in range(filename.count())
-                ]
+                selection = [filename.objectAtIndex_(x).UTF8String() for x in range(filename.count())]
 
         self._handle_selection(selection)
 

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -98,18 +98,21 @@ class MacFileChooser:
             url = NSURL.fileURLWithPath_(self.path)
             panel.setDirectoryURL_(url)
 
+        selection = ['']
+
         if panel.runModal():
-            selection = None
             if self.mode == "save" or not self.multiple:
                 selection = [panel.filename().UTF8String()]
             else:
                 filename = panel.filenames()
                 selection = [
                     filename.objectAtIndex_(x).UTF8String()
-                    for x in range(filename.count())]
-            self._handle_selection(selection)
-            return selection
-        return None
+                    for x in range(filename.count())
+                ]
+
+        self._handle_selection(selection)
+
+        return selection
 
 
 class MacOSXFileChooser(FileChooser):

--- a/plyer/platforms/macosx/filechooser.py
+++ b/plyer/platforms/macosx/filechooser.py
@@ -105,7 +105,9 @@ class MacFileChooser:
                 selection = [panel.filename().UTF8String()]
             else:
                 filename = panel.filenames()
-                selection = [filename.objectAtIndex_(x).UTF8String() for x in range(filename.count())]
+                selection = [
+                    filename.objectAtIndex_(x).UTF8String()
+                    for x in range(filename.count())]
 
         self._handle_selection(selection)
 


### PR DESCRIPTION
When clicking the close button, on OS X on_selection was not called
```py
from textwrap import dedent

from plyer import filechooser

from kivy.app import App
from kivy.lang import Builder
from kivy.properties import ListProperty
from kivy.uix.button import Button


class FileChoose(Button):
    '''
    Button that triggers 'filechooser.open_file()' and processes
    the data response from filechooser Activity.
    '''

    selection = ListProperty([])

    def choose(self):
        '''
        Call plyer filechooser API to run a filechooser Activity.
        '''
        filechooser.open_file(on_selection=self.handle_selection)

    def handle_selection(self, selection):
        '''
        Callback function for handling the selection response from Activity.
        '''
        self.selection = selection

    def on_selection(self, *a, **k):
        '''
        Update TextInput.text after FileChoose.selection is changed
        via FileChoose.handle_selection.
        '''
        print(self.selection)
        App.get_running_app().root.ids.result.text = str(self.selection)


class ChooserApp(App):
    '''
    Application class with root built in KV.
    '''

    def build(self):
        return Builder.load_string(dedent('''
            <FileChoose>:
            BoxLayout:
                BoxLayout:
                    orientation: 'vertical'
                    TextInput:
                        id: result
                        text: ''
                        hint_text: 'selected path'
                    FileChoose:
                        size_hint_y: 0.1
                        on_release: self.choose()
                        text: 'Select a file'
        ''')
                                   )


if __name__ == '__main__':
    ChooserApp().run()
```

https://user-images.githubusercontent.com/40869738/154804345-a0b47343-403c-4ee3-8aa5-9c909be5e19a.mp4


