### PR TITLE
Added the ability to track the closure of the file manager without selecting content

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -64,14 +64,15 @@ class SubprocessFileChooser:
             if ret is not None:
                 if ret == self.successretcode:
                     out = self._process.communicate()[0].strip().decode('utf8')
-                    self.selection = self._split_output(out)
-                    self._handle_selection(self.selection)
-                    return self.selection
+                    return self._set_and_return_selection(self._split_output(out))
                 else:
-                    self.selection = None
-                    self._handle_selection(self.selection)
-                    return self.selection
+                    return self._set_and_return_selection(None)
             time.sleep(0.1)
+
+    def _set_and_return_selection(self, value):
+        self.selection = value
+        self._handle_selection(value)
+        return value
 
     def _split_output(self, out):
         '''This methods receives the output of the back-end and turns

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -68,7 +68,10 @@ class SubprocessFileChooser:
                     self._handle_selection(self.selection)
                     return self.selection
                 else:
-                    return None
+                    self.selection = None
+                    self._handle_selection(self.selection)
+                    return self.selection
+                
             time.sleep(0.1)
 
     def _split_output(self, out):

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -71,7 +71,6 @@ class SubprocessFileChooser:
                     self.selection = None
                     self._handle_selection(self.selection)
                     return self.selection
-                
             time.sleep(0.1)
 
     def _split_output(self, out):


### PR DESCRIPTION
When clicking the close button, on *Linux* `on_selection` was not called. Same - #666 
```py
from textwrap import dedent

from plyer import filechooser

from kivy.app import App
from kivy.lang import Builder
from kivy.properties import ListProperty
from kivy.uix.button import Button


class FileChoose(Button):
    '''
    Button that triggers 'filechooser.open_file()' and processes
    the data response from filechooser Activity.
    '''

    selection = ListProperty([], allownone=True)

    def choose(self):
        '''
        Call plyer filechooser API to run a filechooser Activity.
        '''
        filechooser.open_file(on_selection=self.handle_selection)

    def handle_selection(self, selection):
        '''
        Callback function for handling the selection response from Activity.
        '''
        self.selection = selection

    def on_selection(self, *a, **k):
        '''
        Update TextInput.text after FileChoose.selection is changed
        via FileChoose.handle_selection.
        '''
        print(self.selection)
        App.get_running_app().root.ids.result.text = str(self.selection)


class ChooserApp(App):
    '''
    Application class with root built in KV.
    '''

    def build(self):
        return Builder.load_string(dedent('''
            <FileChoose>:
            BoxLayout:
                BoxLayout:
                    orientation: 'vertical'
                    TextInput:
                        id: result
                        text: ''
                        hint_text: 'selected path'
                    FileChoose:
                        size_hint_y: 0.1
                        on_release: self.choose()
                        text: 'Select a file'
        ''')
                                   )


if __name__ == '__main__':
    ChooserApp().run()

```