### PR TITLE
More robust way to get application icon on Android for notification

### DIFF
--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -26,7 +26,6 @@ AndroidString = autoclass('java.lang.String')
 Context = autoclass('android.content.Context')
 NotificationBuilder = autoclass('android.app.Notification$Builder')
 NotificationManager = autoclass('android.app.NotificationManager')
-Drawable = autoclass("{}.R$mipmap".format(activity.getPackageName()))
 PendingIntent = autoclass('android.app.PendingIntent')
 Intent = autoclass('android.content.Intent')
 Toast = autoclass('android.widget.Toast')
@@ -41,8 +40,17 @@ class AndroidNotification(Notification):
     '''
 
     def __init__(self):
+        package_name = activity.getPackageName()
         self._ns = None
-        self._channel_id = activity.getPackageName()
+        self._channel_id = package_name
+
+        pm = activity.getPackageManager()
+        info = pm.getActivityInfo(activity.getComponentName(), 0)
+        if info.icon == 0:
+            # Take the application icon instead.
+            info = pm.getApplicationInfo(package_name, 0)
+
+        self._app_icon = info.icon
 
     def _get_notification_service(self):
         if not self._ns:
@@ -87,8 +95,7 @@ class AndroidNotification(Notification):
             Toast.LENGTH_LONG
         ).show()
 
-    @staticmethod
-    def _set_icons(notification, icon=None):
+    def _set_icons(self, notification, icon=None):
         '''
         Set the small application icon displayed at the top panel together with
         WiFi, battery percentage and time and the big optional icon (preferably
@@ -97,7 +104,7 @@ class AndroidNotification(Notification):
 
         .. versionadded:: 1.4.0
         '''
-        app_icon = Drawable.icon
+        app_icon = self._app_icon
         notification.setSmallIcon(app_icon)
 
         bitmap_icon = app_icon


### PR DESCRIPTION
Firstly, thank you so much for developing such a great library!  I'm excited to say that I've been having good success getting it to work with Panda3D applications.  There's one main obstacle that I can't overcome without changes to plyer, though.

Currently, the Notification implementation on Android makes the bold assumption that there is an R.class which has a field named "icon" that points to the icon resource of the application.  This need not be the case; the icon may not be named "icon" precisely, or there may not even be an R.class at all, since this is not actually required by Android, and it would be very painful to try and get Panda3D's packaging tool to compile an R.class file specifically for the sake of getting plyer to work.

So, this PR instead changes the mechanism to use the PackageManager to determine the actual icon used by the application, regardless of its resource name.  This should produce equivalent results without requiring an R.class or hardcoding the name of the icon resource.

This change has the additional benefit that it will prefer the icon of the Activity over that of the Application, if present, in cases where there are multiple activities in the same application (though I'm not married to this if this is considered undesirable).  I believe p4a uses the same icon for both so it should not negatively affect p4a.

Likely also fixes #591 .

Thanks for your consideration!