### PR TITLE
:hammer: Fix pep 8 failure for CICD

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -64,7 +64,8 @@ class SubprocessFileChooser:
             if ret is not None:
                 if ret == self.successretcode:
                     out = self._process.communicate()[0].strip().decode('utf8')
-                    return self._set_and_return_selection(self._split_output(out))
+                    return self._set_and_return_selection(
+                        self._split_output(out))
                 else:
                     return self._set_and_return_selection(None)
             time.sleep(0.1)


### PR DESCRIPTION
## Background

The automated tests are currently failing due to pep8 violation. This PR fixes that pep8 error.

![Screenshot_2022-04-30_14-59-54](https://user-images.githubusercontent.com/3539755/166106652-b20b88ac-d108-4f7e-9bbc-12b16470ec23.png)
