### PR TITLE
Use xdg-desktop-portal for Notification inside Flatpak

### DIFF
--- a/plyer/platforms/linux/notification.py
+++ b/plyer/platforms/linux/notification.py
@@ -6,6 +6,25 @@ import warnings
 import subprocess
 from plyer.facades import Notification
 from plyer.utils import whereis_exe
+import os
+
+
+class NotifyDesktopPortals(Notification):
+    '''
+    Implementation of xdg-desktop-portals API.
+    '''
+
+    def _notify(self, **kwargs):
+        title = kwargs.get("title", "title")
+        body = kwargs.get("message", "body")
+
+        subprocess.run([
+            "gdbus", "call", "--session", "--dest",
+            "org.freedesktop.portal.Desktop",
+            "--object-path", "/org/freedesktop/portal/desktop", "--method",
+            "org.freedesktop.portal.Notification.AddNotification", "",
+            "{'title': <'" + title + "'>, 'body': <'"+ body + "'>}"
+        ], stdout=subprocess.DEVNULL)
 
 
 class NotifySendNotification(Notification):
@@ -54,6 +73,9 @@ def instance():
     '''
     Instance for facade proxy.
     '''
+    if os.path.isdir("/app"):
+        # Flatpak
+        return NotifyDesktopPortals()
     try:
         import dbus  # noqa: F401
         return NotifyDbus()


### PR DESCRIPTION
When running a Program inside a Flatpak, you have no access to org.freedesktop.Notifications unless you allow it explicit. The notify-send binary is also not available.

This PR adds support for the [Notification API of the xdg-desktop-portal API](https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Notification), so it works out of the box inside Flatpaks.

I use the gdbus binary, because dbus-python is not in the requirements of player and not included in the Flatpak Runtimes. When installing a Python package, that has plyer in it's requirements, dbus-python will not automagically be installed with plyer, what gives Flatpak users a not working package. gdbus however is included in all Runtimes and will work without any Problems.

Just a tip for the Developers:
Some Portals (not all) like the FileChooser Portal can also be used outside Flatpaks. This might be  better way to implement things like the FileChooser function than using things like zenity or kdialog.