### PR TITLE
Fixes a failing test for notification

### DIFF
--- a/plyer/tests/test_notification.py
+++ b/plyer/tests/test_notification.py
@@ -179,7 +179,7 @@ class TestNotification(unittest.TestCase):
                 TestNotification.data['app_icon'],
                 TestNotification.data['title'],
                 TestNotification.data['message'],
-                [], [],
+                [], {},
                 TestNotification.data['timeout'] * 1000
             )
         finally:


### PR DESCRIPTION
- `hints` is a `dict`, but during the test a `list` was expected.