### PR TITLE
Add missing platform for barometer

### DIFF
--- a/plyer/facades/barometer.py
+++ b/plyer/facades/barometer.py
@@ -10,7 +10,7 @@ class Barometer:
 
     .. versionadded:: 1.2.5
 
-    Supported Platforms:: Android
+    Supported Platforms:: Android, iOS
     '''
 
     @property


### PR DESCRIPTION
Fix docstring to include iOS in supported platforms