### PR TITLE
Keyword should only hold name of license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     package_data={'': ['LICENSE', 'README.md']},
     package_dir={'plyer': 'plyer'},
     include_package_data=True,
-    license=open(join(CURDIR, 'LICENSE')).read(),
+    license='LICENSE',
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     package_data={'': ['LICENSE', 'README.md']},
     package_dir={'plyer': 'plyer'},
     include_package_data=True,
-    license='LICENSE',
+    license='MIT',
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
In accordance with pypa/twine#425, `license` keyword [should not](https://github.com/pypa/twine/issues/425#issuecomment-466436196) hold a multi-line file but rather simply be the name for the license. 

Could be potential fix for kivy/plyer#698 where raw Markdown is being displayed on PyPI. I am definitely interested in working for a fix for kivy/plyer#698 but would appreciate some guidance in where to start as I am more of a beginner.