### PR TITLE
SMS support for macOS!

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ implement the api in the easiest way, depending on the current platform.
 | Orientation                    | ✔       |     |         |      | ✔     |
 | Proximity                      | ✔       |     |         |      |       |
 | Screenshot                     |         |     | ✔       | ✔    | ✔     |
-| SMS (send messages)            | ✔       | ✔   |         |      |       |
+| SMS (send messages)            | ✔       | ✔   |         |      | ✔     |
 | Spatial Orientation            | ✔       | ✔   |         |      |       |
 | Speech to text                 | ✔       |     |         |      |       |
 | Storage Path                   | ✔       | ✔   | ✔       | ✔    | ✔     |

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -42,7 +42,8 @@ class Sms:
 
         :param recipient: The receiver
         :param message: the message
-        :param mode: (optional) macOS only, can be set to 'SMS'
+        :param mode: (optional, macOS only), can be set to 'iMessage'
+        (default) or 'SMS'
 
         :type recipient: number
         :type message: str

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -33,7 +33,7 @@ class Sms:
     Sms facade.
     '''
 
-    def send(self, recipient, message, mode='iMessage', **kwargs):
+    def send(self, recipient, message, **kwargs):
         '''
         Send SMS or open SMS interface.
 
@@ -43,7 +43,7 @@ class Sms:
         :type recipient: number
         :type message: str
         '''
-        self._send(recipient=recipient, message=message, mode=mode)
+        self._send(recipient=recipient, message=message, **kwargs)
 
     # private
 

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -36,12 +36,17 @@ class Sms:
     def send(self, recipient, message, mode=None, **kwargs):
         '''
         Send SMS or open SMS interface.
+        Includes optional `mode` parameter for macOS that can be set to
+        `'SMS'` if carrier-activated device is correctly paired and
+        configured to macOS.
 
         :param recipient: The receiver
         :param message: the message
+        :param mode: (optional) macOS only, can be set to 'SMS'
 
         :type recipient: number
         :type message: str
+        :type mode: str
         '''
         self._send(recipient=recipient, message=message, mode=mode, **kwargs)
 

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -33,7 +33,7 @@ class Sms:
     Sms facade.
     '''
 
-    def send(self, recipient, message, **kwargs):
+    def send(self, recipient, message, mode=None, **kwargs):
         '''
         Send SMS or open SMS interface.
 
@@ -43,7 +43,7 @@ class Sms:
         :type recipient: number
         :type message: str
         '''
-        self._send(recipient=recipient, message=message, **kwargs)
+        self._send(recipient=recipient, message=message, mode=mode, **kwargs)
 
     # private
 

--- a/plyer/facades/sms.py
+++ b/plyer/facades/sms.py
@@ -23,7 +23,7 @@ To send sms::
 
 Supported Platforms
 -------------------
-Android, iOS
+Android, iOS, macOS
 
 '''
 
@@ -33,7 +33,7 @@ class Sms:
     Sms facade.
     '''
 
-    def send(self, recipient, message):
+    def send(self, recipient, message, mode='iMessage', **kwargs):
         '''
         Send SMS or open SMS interface.
 
@@ -43,7 +43,7 @@ class Sms:
         :type recipient: number
         :type message: str
         '''
-        self._send(recipient=recipient, message=message)
+        self._send(recipient=recipient, message=message, mode=mode)
 
     # private
 

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -29,8 +29,8 @@ class MacOSSMS(SMS):
     send "{message}" to targetBuddy
 end tell"""
 
-        osascript_process = Popen(['osascript', '-e', APPLESCRIPT],
-                                stdout=PIPE, stderr=PIPE)
+        osascript_process = Popen(
+            ['osascript', '-e', APPLESCRIPT], stdout=PIPE, stderr=PIPE)
         stdout, stderr = osascript_process.communicate()
 
 

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -12,16 +12,14 @@ class MacOSSMS(SMS):
         '''
         Will send `message` to `recipient` via Messages app
 
-        Currently only supports iMessage as macOS can send that standalone
-        In order to support SMS, a valid carrier-activated device must be
-        connected & configured to macOS
-            - activate this by passing in mode='SMS'
-
+        By default, if `mode` is not explicitly set, `iMessage` is used.
+        In order to use `SMS` mode, a valid carrier-activated device must
+        be connected and configured.
         '''
 
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')
-        mode = kwargs.get('mode')  # can be SMS
+        mode = kwargs.get('mode')  # Supported modes: iMessage (default), SMS
         if not mode:
             mode = 'iMessage'
 

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -21,7 +21,7 @@ class OSXSMS(SMS):
 
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')
-        mode = kwargs.get('mode', 'iMessage') # can be SMS
+        mode = kwargs.get('mode', 'iMessage')  # can be SMS
 
         APPLESCRIPT = f"""tell application "Messages"
     set targetService to 1st account whose service type = {mode}
@@ -30,7 +30,7 @@ class OSXSMS(SMS):
 end tell"""
 
         osascript_process = Popen(['osascript', '-e', APPLESCRIPT],
-                                    stdout=PIPE, stderr=PIPE)
+                                stdout=PIPE, stderr=PIPE)
         stdout, stderr = osascript_process.communicate()
 
 

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -3,7 +3,7 @@ from plyer.facades import Sms as SMS
 from plyer.utils import whereis_exe
 
 
-class OSXSMS(SMS):
+class MacOSSMS(SMS):
     '''
     Implementation of macOS' Messages API
     '''
@@ -37,6 +37,6 @@ end tell"""
 def instance():
     import sys
     if whereis_exe('osascript'):
-        return OSXSMS()
+        return MacOSSMS()
     sys.stderr.write('osascript not found.')
     return SMS()

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -21,7 +21,9 @@ class MacOSSMS(SMS):
 
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')
-        mode = kwargs.get('mode', 'iMessage')  # can be SMS
+        mode = kwargs.get('mode')  # can be SMS
+        if not mode:
+            mode = 'iMessage'
 
         APPLESCRIPT = f"""tell application "Messages"
     set targetService to 1st account whose service type = {mode}

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -7,21 +7,22 @@ class OSXSMS(SMS):
     '''
     Implementation of macOS' Messages API
     '''
-    
+
     def _send(self, **kwargs):
         '''
         Will send `message` to `recipient` via Messages app
-        
+
         Currently only supports iMessage as macOS can send that standalone
-        In order to support SMS, a valid carrier-activated device must be connected & configured to macOS
+        In order to support SMS, a valid carrier-activated device must be
+        connected & configured to macOS
             - activate this by passing in mode='SMS'
-        
+
         '''
-        
+
         recipient = kwargs.get('recipient')
         message = kwargs.get('message')
         mode = kwargs.get('mode', 'iMessage') # can be SMS
-       
+
         APPLESCRIPT = f"""tell application "Messages"
     set targetService to 1st account whose service type = {mode}
     set targetBuddy to participant "{recipient}" of targetService
@@ -29,10 +30,10 @@ class OSXSMS(SMS):
 end tell"""
 
         osascript_process = Popen(['osascript', '-e', APPLESCRIPT],
-        stdout=PIPE, stderr=PIPE)
+                                    stdout=PIPE, stderr=PIPE)
         stdout, stderr = osascript_process.communicate()
-        
-        
+
+
 def instance():
     import sys
     if whereis_exe('osascript'):

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -1,0 +1,54 @@
+from subprocess import Popen, PIPE
+from plyer.facades import Sms as SMS
+from plyer.utils import whereis_exe
+
+
+class OSXSMS(SMS):
+    '''
+    Implementation of macOS' Messages API
+    '''
+    
+    def _send(self, **kwargs):
+        '''
+        Will send `message` to `recipient` via Messages app
+        
+        Currently only supports iMessage as macOS can send that standalone
+        In order to support SMS, a valid carrier-activated device must be connected & configured to macOS
+            - activate this by passing in mode='SMS'
+        
+        '''
+        
+        recipient = kwargs.get('recipient')
+        message = kwargs.get('message')
+        mode = kwargs.get('mode', 'iMessage') # can be SMS
+       
+        APPLESCRIPT = f"""tell application "Messages"
+    set targetService to 1st account whose service type = {mode}
+    set targetBuddy to participant "{recipient}" of targetService
+    send "{message}" to targetBuddy
+end tell"""
+
+        osascript_process = Popen(['osascript', '-e', APPLESCRIPT],
+        stdout=PIPE, stderr=PIPE)
+        stdout, stderr = osascript_process.communicate()
+        
+        
+def instance():
+    import sys
+    if whereis_exe('osascript'):
+        return OSXSMS()
+    sys.stderr.write('osascript not found.')
+    return SMS()
+
+        
+
+        
+
+        
+
+        
+        
+
+
+
+

--- a/plyer/platforms/macosx/sms.py
+++ b/plyer/platforms/macosx/sms.py
@@ -39,16 +39,3 @@ def instance():
         return OSXSMS()
     sys.stderr.write('osascript not found.')
     return SMS()
-
-        
-
-        
-
-        
-
-        
-        
-
-
-
-


### PR DESCRIPTION
Extending support for sending messages for macOS systems!

Couple things to note:
- The implementation is really meant for iMessages, as are natively supported by macOS. SMS will only work on macOS if a device that is carrier-activated is [correctly paired and configured](https://support.apple.com/guide/messages/get-sms-texts-from-iphone-on-your-mac-icht8a28bb9a/mac). If SMS is desired, simply passing it into `sms.send(mode='SMS')` will correctly switch the mode. 
- My implementation has been tested with the existing example, and does work on on `macOS Monterey 12.5`