### PR TITLE
correction for call getParameters using the object created at flashli…

### DIFF
--- a/plyer/platforms/android/flash.py
+++ b/plyer/platforms/android/flash.py
@@ -42,8 +42,8 @@ class AndroidFlash(Flash):
         if not flash_available:
             return
         self._camera = Camera.open()
-        self._f_on = Camera.getParameters()
-        self._f_off = Camera.getParameters()
+        self._f_on = self._camera.getParameters()
+        self._f_off = self._camera.getParameters()
         self._f_on.setFlashMode(CameraParameters.FLASH_MODE_TORCH)
         self._f_off.setFlashMode(CameraParameters.FLASH_MODE_OFF)
         self._camera.startPreview()


### PR DESCRIPTION
With this changes i was able to get working the flashlight under android 5.0 and maybe in other android versions, issue related is #668 