### PR TITLE
Bump action-gh-release to a newer version

### DIFF
--- a/.github/workflows/plyer_deploy.yml
+++ b/.github/workflows/plyer_deploy.yml
@@ -32,7 +32,7 @@ jobs:
         path: dist
 
     - name: Upload to GitHub Releases
-      uses: softprops/action-gh-release@v0.1.5
+      uses: softprops/action-gh-release@v0.1.14
 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_RELEASE }}


### PR DESCRIPTION
- Bumps `action-gh-release` to a newer version, in order to get ready for a new plyer release.