### PR TITLE
action-gh-release now uses `github.token`

### DIFF
--- a/.github/workflows/plyer_deploy.yml
+++ b/.github/workflows/plyer_deploy.yml
@@ -33,10 +33,6 @@ jobs:
 
     - name: Upload to GitHub Releases
       uses: softprops/action-gh-release@v0.1.14
-
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_RELEASE }}
-
       with:
         files: dist/*
         draft: true


### PR DESCRIPTION
`action-gh-release` now uses `github.token` (by default, so doesn't need any config)