### PR TITLE
feat(android-filechooser): Implement save file method

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -231,8 +231,12 @@ class AndroidFileChooser(FileChooser):
         elif request_code == self.save_code:
             uri = data.getData()
 
-            with mActivity.getContentResolver().openFileDescriptor(uri, "w") as pfd:
-                with FileOutputStream(pfd.getFileDescriptor()) as fileOutputStream:
+            with mActivity.getContentResolver().openFileDescriptor(
+                uri, "w"
+            ) as pfd:
+                with FileOutputStream(
+                    pfd.getFileDescriptor()
+                ) as fileOutputStream:
                     # return value via callback
                     self._save_callback(fileOutputStream)
 


### PR DESCRIPTION
**This works like a charm!**
Tested on: _python 3.8.15; kivy 2.1.0;  plyer 2.1.0; Android 13 on pure AOSP_


**Pros:**
- [x] _**This doesn't need any permissions. Neither any manifest nor config changes (Absolutely no any).**_

- [x] _**Always uses the default file explorer in the system.**_

- [x] Purely native code approved by the Google's android guide.

- [x] The same code (but in Kotlin) tested with my production app on **5, 7, 9, 10, 12, 13** versions of Android.

- [x] This supports the default file name value as `title` argument.

- [x] Comfortable handling of the file output stream with the callback argument. Not so good due to the lack of type hints but there always are the java docs!


**Cons:**
Still uses deprecated onActivityResult (same as `open_file` does. I think this is not so bad (This also used on the Google's guide).



Improvements and tests are appreciated!

Closes #661  ;)

