### PR TITLE
Add pywin32 as optional dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ try:
                 'ios': ['pyobjus'],
                 'macosx': ['pyobjus'],
                 'android': ['pyjnius'],
+                'win': ['pywin32'],
                 'dev': ['mock', 'flake8']
             }
         }
@@ -81,5 +82,9 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
     ],
+    # Alternativly, add pywin32 as a Platform dependancy
+    # install_requires=[ 
+    #     "pywin32;platform_system=='Windows'",
+    # ],
     **EXTRA_OPTIONS
 )


### PR DESCRIPTION
Fix for #735 

add pywin32 dependency when installing with the [win] option.
Alternative, it could be added as a platform specific dependency for windows(added, but commented out)

I'm not sure which is the most ideal behavior, thoughts?
