### PR TITLE
YADFileChooser: s/--file-selection/--file/

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -195,7 +195,7 @@ class YADFileChooser(SubprocessFileChooser):
     def _gen_cmdline(self):
         cmdline = [
             which(self.executable),
-            "--file-selection",
+            "--file",
             "--confirm-overwrite",
             "--geometry",
             "800x600+150+150"


### PR DESCRIPTION
YAD removed support for its --file-selection option, which was an alias for --file, in commit 50c964d742 on Aug 4, 2019 (that commit removed all ...-selection aliases).

This change passes --file instead, which is present in all versions of YAD on GitHub to date.

I tested this by running it under WSL2 with YAD installed (all in a conda environment) and observing that the resulting YAD dialog now shows the file chooser dialog.

closes #744 