### PR TITLE
Fixes error when selecting a file from the `Downloads` option in the navigation panel

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -325,6 +325,23 @@ class AndroidFileChooser(FileChooser):
         .. versionadded:: 1.4.0
         '''
 
+        try:
+            download_dir = Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DOWNLOADS
+            ).getPath()
+            path = AndroidFileChooser._parse_content(
+                uri=uri,
+                projection=["_display_name"],
+                selection=None,
+                selection_args=None,
+                sort_order=None,
+            )
+            return join(download_dir, path)
+
+        except Exception:
+            import traceback
+            traceback.print_exc()
+
         # known locations, differ between machines
         downloads = [
             'content://downloads/public_downloads',


### PR DESCRIPTION
This PR fixes the error when selecting a file from the sidebar `Downloads` option. In most cases the selection would fail with the following errors:

1. invalid URI:
  jnius.jnius.JavaException: JVM exception occurred: Unknown URI: content://downloads/public_downloads/1034

2. missing URI / android permissions
  jnius.jnius.JavaException: JVM exception occurred: Permission Denial: reading com.android.providers.downloads.DownloadProvider uri content://downloads/all_downloads/1034 from pid=2532, uid=10455 requires android.permission.ACCESS_ALL_DOWNLOADS, or grantUriPermission()

**Note:** The previous code was kept, in case the first option fails.

### Tested on:

`python-for-android` version: `2023.2.10`
`buildozer` version: `1.5.0`

**Android API levels:**
- `27`
- `28`
- `31`
