### PR TITLE
Fixed issue accessing sd_card path in newer Android APIs

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -43,7 +43,7 @@ using that result will use an incorrect one i.e. the default value of
 .. versionadded:: 1.4.0
 '''
 
-from os.path import join, basename
+from os.path import join
 from random import randint
 
 from android import activity, mActivity
@@ -252,28 +252,19 @@ class AndroidFileChooser(FileChooser):
         file_id = DocumentsContract.getDocumentId(uri)
         file_type, file_name = file_id.split(':')
 
-        # internal SD card mostly mounted as a files storage in phone
-        internal = storagepath.get_external_storage_dir()
+        primary_storage = storagepath.get_external_storage_dir()
+        sdcard_storage = storagepath.get_sdcard_dir()
 
-        # external (removable) SD card i.e. microSD
-        external = storagepath.get_sdcard_dir()
-        try:
-            external_base = basename(external)
-        except TypeError:
-            external_base = basename(internal)
+        directory = primary_storage
 
-        # resolve sdcard path
-        sd_card = internal
-
-        # because external might have /storage/.../1 or other suffix
-        # and file_type might be only a part of the real folder in /storage
-        if file_type in external_base or external_base in file_type:
-            sd_card = external
+        if file_type == "primary":
+            directory = primary_storage
         elif file_type == "home":
-            sd_card = join(Environment.getExternalStorageDirectory(
-            ).getAbsolutePath(), Environment.DIRECTORY_DOCUMENTS)
+            directory = join(primary_storage, Environment.DIRECTORY_DOCUMENTS)
+        elif sdcard_storage and file_type in sdcard_storage:
+            directory = sdcard_storage
 
-        return join(sd_card, file_name)
+        return join(directory, file_name)
 
     @staticmethod
     def _handle_media_documents(uri):

--- a/plyer/platforms/android/storagepath.py
+++ b/plyer/platforms/android/storagepath.py
@@ -3,14 +3,12 @@ Android Storage Path
 --------------------
 '''
 
-from os import listdir, access, R_OK
-from os.path import join
 from plyer.facades import StoragePath
-from jnius import autoclass
+from jnius import autoclass, cast
 from android import mActivity
 
-Environment = autoclass('android.os.Environment')
-Context = autoclass('android.content.Context')
+Environment = autoclass("android.os.Environment")
+Context = autoclass("android.content.Context")
 
 
 class AndroidStoragePath(StoragePath):
@@ -25,17 +23,23 @@ class AndroidStoragePath(StoragePath):
         '''
         .. versionadded:: 1.4.0
         '''
-        # folder in /storage/ that is readable
-        # and is not internal SD card
         path = None
-        for folder in listdir('/storage'):
-            folder = join('/storage', folder)
-            if folder in self._get_external_storage_dir():
-                continue
-            if not access(folder, R_OK):
-                continue
-            path = folder
-            break
+        context = mActivity.getApplicationContext()
+        storage_manager = cast(
+            "android.os.storage.StorageManager",
+            context.getSystemService(Context.STORAGE_SERVICE),
+        )
+
+        if storage_manager is not None:
+            storage_volumes = storage_manager.getStorageVolumes()
+            for storage_volume in storage_volumes:
+                if storage_volume.isRemovable():
+                    try:
+                        directory = storage_volume.getDirectory()
+                    except AttributeError:
+                        directory = storage_volume.getPathFile()
+                    path = directory.getAbsolutePath()
+
         return path
 
     def _get_root_dir(self):


### PR DESCRIPTION
When trying to access the memory card directory in the latest android APIs, an error occurs.

Newer API levels do not allow access to content within `/storage`, resulting in a permissions error.


### Tested on:

`python-for-android` version: `2023.2.10`
`buildozer` version: `1.5.0`

**Android API levels:**
- `27`
- `28`
- `31`
