### PR TITLE
Fixes error when selecting a file from the `Documents` option in newer Android APIs

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -62,6 +62,7 @@ Long = autoclass('java.lang.Long')
 IMedia = autoclass('android.provider.MediaStore$Images$Media')
 VMedia = autoclass('android.provider.MediaStore$Video$Media')
 AMedia = autoclass('android.provider.MediaStore$Audio$Media')
+Files = autoclass('android.provider.MediaStore$Files')
 FileOutputStream = autoclass('java.io.FileOutputStream')
 
 
@@ -294,6 +295,11 @@ class AndroidFileChooser(FileChooser):
             uri = VMedia.EXTERNAL_CONTENT_URI
         elif file_type == 'audio':
             uri = AMedia.EXTERNAL_CONTENT_URI
+
+        # Other file type was selected (probably in the Documents folder)
+        else:
+            uri = Files.getContentUri("external")
+
         return file_name, selection, uri
 
     @staticmethod


### PR DESCRIPTION
When selecting a file in the `Documents` option in the navigation panel, the `uri_authority` returned is `'com.android.providers.media.documents'`. However the selection will fail because the `_handle_media_documents` method only handles `audio`, `video` or `image` and ignores any other type of file. Finally, `None` will be returned as the file path.

### Tested on:

`python-for-android` version: `2023.2.10`
`buildozer` version: `1.5.0`

**Android API levels:**
- `27`
- `28`
- `31`