### PR TITLE
android: fix notification.notify() for sdk>=31, by setting new req flag

### DIFF
--- a/plyer/platforms/android/notification.py
+++ b/plyer/platforms/android/notification.py
@@ -148,10 +148,15 @@ class AndroidNotification(Notification):
         notification_intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         notification_intent.setAction(Intent.ACTION_MAIN)
         notification_intent.addCategory(Intent.CATEGORY_LAUNCHER)
+        if SDK_INT >= 23:
+            # FLAG_IMMUTABLE added in SDK 23, required since SDK 31:
+            pending_flags = PendingIntent.FLAG_IMMUTABLE
+        else:
+            pending_flags = 0
 
         # get our application Activity
         pending_intent = PendingIntent.getActivity(
-            app_context, 0, notification_intent, 0
+            app_context, 0, notification_intent, pending_flags
         )
 
         notification.setContentIntent(pending_intent)


### PR DESCRIPTION
fixes https://github.com/kivy/plyer/issues/702

see https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability
> Pending intents mutability
>   If your app targets Android 12, you must specify the mutability of
>   each PendingIntent object that your app creates. This additional
>   requirement improves your app's security.

see https://stackoverflow.com/q/69088578

Without this, I get the following exception: `JavaException('JVM exception occurred: org.electrum.testnet.electrum: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.\nStrongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles. java.lang.IllegalArgumentException')`

As in code comment, [`PendingIntent.FLAG_IMMUTABLE`](https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE) was introduced in sdk 23.
Prior to sdk 31, if `FLAG_IMMUTABLE` is not set, the intent is implicitly mutable. Starting with sdk 31, either `PendingIntent.FLAG_IMMUTABLE` or `PendingIntent.FLAG_MUTABLE` needs to be explicitly specified.
AFAICT, we can just always set `FLAG_IMMUTABLE` (if sdk>=23), which is what this PR does. However, I have only tested on Android 13 (api level 33).