### PR TITLE
:pencil2: Fix github.ref typo on coverage upload

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -47,7 +47,7 @@ jobs:
         tests
 
     - name: Upload Coverage
-      if: github.event_name == 'push' && github.ref == 'refs/head/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |


### PR DESCRIPTION
This led to the coverage never being uploaded for this job