### PR TITLE
Choose a reasonable and valid number for the intent code and use the uri variable

### DIFF
--- a/plyer/platforms/android/filechooser.py
+++ b/plyer/platforms/android/filechooser.py
@@ -107,8 +107,8 @@ class AndroidFileChooser(FileChooser):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.select_code = randint(123456, 654321)
-        self.save_code = randint(123456, 654321)
+        self.select_code = randint(100, 65536) # 65536 is the maximum. 100 to avoid conflicts.
+        self.save_code = randint(100, 65536)
         self.selection = None
 
         # bind a function for a response from filechooser activity
@@ -454,7 +454,7 @@ class AndroidFileChooser(FileChooser):
         elif uri_scheme == 'file':
             path = uri.getPath()
 
-        return path
+        return path or uri
 
     @staticmethod
     def _parse_content(


### PR DESCRIPTION
This PR make the `Android file chooser` use a reasonable and valid number in the intent code.

This PR contains another minor changes: in the `_resolve_uri` function, if the `uri` came from the `com.android.providers.media.documents` provider, it defines the `uri` variable, but don't actually use it, and return `path` which is still `None`, so this minor change make this method return `path or uri`.