### PR TITLE
Normalize path when passing args to windows filechooser

### DIFF
--- a/plyer/platforms/win/filechooser.py
+++ b/plyer/platforms/win/filechooser.py
@@ -12,7 +12,7 @@ from win32com.shell import shellcon
 import win32gui
 import win32con
 import pywintypes
-from os.path import dirname, splitext, join, isdir
+from os.path import dirname, splitext, join, isdir, normpath
 
 
 class Win32FileChooser:
@@ -65,6 +65,7 @@ class Win32FileChooser:
                 args = {}
 
                 if self.path:
+                    self.path = normpath(self.path)
                     if isdir(self.path):
                         args["InitialDir"] = self.path
                     else:


### PR DESCRIPTION
This changes the Win32FileChooser to apply `os.path.normpath` to the path parameter before passing it on to pywin32. This allows the filechooser's path parameter to work properly without the end-user having to normalize the path first.