### PR TITLE
Exact match lookup for MacOS battery status

### DIFF
--- a/plyer/platforms/macosx/battery.py
+++ b/plyer/platforms/macosx/battery.py
@@ -32,11 +32,11 @@ class OSXBattery(Battery):
 
         is_charging = max_capacity = current_capacity = None
         for line in output.decode('utf-8').splitlines():
-            if 'IsCharging' in line:
+            if 'IsCharging' == line.rpartition('=')[0].strip()[1:-1]:
                 is_charging = line.rpartition('=')[-1].strip()
-            if 'MaxCapacity' in line:
+            if 'MaxCapacity' == line.rpartition('=')[0].strip()[1:-1]:
                 max_capacity = float(line.rpartition('=')[-1].strip())
-            if 'CurrentCapacity' in line:
+            if 'CurrentCapacity' == line.rpartition('=')[0].strip()[1:-1]:
                 current_capacity = float(line.rpartition('=')[-1].strip())
 
         if is_charging:


### PR DESCRIPTION
Fix #799
Use exact string math instead of partial match to look for battery status. This will prevent fields like AppleRawMaxCapacity and AppleRawCurrentCapacity from being read as MaxCapacity and CurrentCapacity.