### PR TITLE
replace old mock by unittest.mock

### DIFF
--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -1,4 +1,3 @@
-mock
 coverage
 coveralls
 cython

--- a/plyer/tests/test_battery.py
+++ b/plyer/tests/test_battery.py
@@ -13,7 +13,7 @@ import unittest
 from io import BytesIO
 from os.path import join
 from textwrap import dedent
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from plyer.tests.common import PlatformTest, platform_import
 

--- a/plyer/tests/test_cpu.py
+++ b/plyer/tests/test_cpu.py
@@ -11,8 +11,8 @@ Tested platforms:
 import unittest
 from os import environ
 from os.path import join
-from mock import patch, Mock
 from textwrap import dedent
+from unittest.mock import patch, Mock
 
 from plyer.tests.common import PlatformTest, platform_import, splitpath
 

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -7,10 +7,11 @@ Tested platforms:
 * Windows
 '''
 
-import unittest
-from mock import patch
-from plyer.tests.common import PlatformTest, platform_import
 import socket
+import unittest
+from unittest.mock import patch
+
+from plyer.tests.common import PlatformTest, platform_import
 
 
 class TestDeviceName(unittest.TestCase):

--- a/plyer/tests/test_email.py
+++ b/plyer/tests/test_email.py
@@ -8,8 +8,8 @@ Tested platforms:
 '''
 
 import unittest
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from plyer.tests.common import PlatformTest, platform_import
 
 

--- a/plyer/tests/test_facade.py
+++ b/plyer/tests/test_facade.py
@@ -16,7 +16,7 @@ import unittest
 import sys
 from types import MethodType
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 import plyer
 

--- a/plyer/tests/test_notification.py
+++ b/plyer/tests/test_notification.py
@@ -13,8 +13,8 @@ import sys
 
 from time import sleep
 from os.path import dirname, abspath, join
+from unittest.mock import Mock, patch
 
-from mock import Mock, patch
 from plyer.tests.common import PlatformTest, platform_import
 
 

--- a/plyer/tests/test_screenshot.py
+++ b/plyer/tests/test_screenshot.py
@@ -12,8 +12,8 @@ import unittest
 
 from os import mkdir, remove
 from os.path import join, expanduser, exists
+from unittest.mock import patch
 
-from mock import patch
 from plyer.tests.common import PlatformTest, platform_import
 
 

--- a/plyer/tests/test_uniqueid.py
+++ b/plyer/tests/test_uniqueid.py
@@ -8,7 +8,8 @@ Tested platforms:
 '''
 
 import unittest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
+
 from plyer.tests.common import PlatformTest, platform_import
 
 

--- a/plyer/tests/test_utils.py
+++ b/plyer/tests/test_utils.py
@@ -12,7 +12,7 @@ Tested platforms:
 '''
 
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 class TestUtils(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
                 'ios': ['pyobjus'],
                 'macosx': ['pyobjus'],
                 'android': ['pyjnius'],
-                'dev': ['mock', 'flake8']
+                'dev': ['flake8']
             }
         }
     )


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock