### PR TITLE
Added feature to return macOS desktop path for StoragePath

### DIFF
--- a/plyer/facades/storagepath.py
+++ b/plyer/facades/storagepath.py
@@ -27,7 +27,9 @@ To get the path of directory holding application files::
     >>> from plyer import storagepath
     >>> storagepath.get_application_dir()
 
+
 '''
+
 
 
 class StoragePath:
@@ -101,7 +103,12 @@ class StoragePath:
         Get the path of the directory holding application files.
         '''
         return self._get_application_dir()
-
+    
+    def get_desktop_dir(self):
+        '''
+        Get the path of the directory holding application files.
+        '''
+        return self._get_desktop_dir()
     # private
 
     def _get_home_dir(self):
@@ -132,4 +139,7 @@ class StoragePath:
         raise NotImplementedError()
 
     def _get_application_dir(self):
+        raise NotImplementedError()
+    
+    def _get_desktop_dir(self):
         raise NotImplementedError()

--- a/plyer/facades/storagepath.py
+++ b/plyer/facades/storagepath.py
@@ -103,13 +103,6 @@ class StoragePath:
         Get the path of the directory holding application files.
         '''
         return self._get_application_dir()
-    
-    def get_desktop_dir(self):
-        '''
-        Get the path of the directory holding application files.
-        '''
-        return self._get_desktop_dir()
-    # private
 
     def _get_home_dir(self):
         raise NotImplementedError()
@@ -140,6 +133,4 @@ class StoragePath:
 
     def _get_application_dir(self):
         raise NotImplementedError()
-    
-    def _get_desktop_dir(self):
-        raise NotImplementedError()
+   

--- a/plyer/facades/storagepath.py
+++ b/plyer/facades/storagepath.py
@@ -103,10 +103,17 @@ class StoragePath:
         Get the path of the directory holding application files.
         '''
         return self._get_application_dir()
+    
+    def get_desktop_dir(self):
+        '''
+        Get the path of the directory holding application files.
+        '''
+        return self._get_desktop_dir()
+
 
     def _get_home_dir(self):
         raise NotImplementedError()
-
+    
     def _get_external_storage_dir(self):
         raise NotImplementedError()
 
@@ -134,3 +141,5 @@ class StoragePath:
     def _get_application_dir(self):
         raise NotImplementedError()
    
+    def _get_desktop_dir(self):
+        raise NotImplementedError()

--- a/plyer/platforms/ios/storagepath.py
+++ b/plyer/platforms/ios/storagepath.py
@@ -16,6 +16,7 @@ NSDownloadsDirectory = 15
 NSMoviesDirectory = 17
 NSMusicDirectory = 18
 NSPicturesDirectory = 19
+NSDesktopDirectory = 12
 
 
 class iOSStoragePath(StoragePath):
@@ -55,6 +56,11 @@ class iOSStoragePath(StoragePath):
     def _get_application_dir(self):
         return self.defaultManager.URLsForDirectory_inDomains_(
             NSApplicationDirectory, 1).firstObject().absoluteString.\
+            UTF8String()
+
+    def _get_desktop_dir(self):
+        return self.defaultManager.URLsForDirectory_inDomains_(
+            NSDesktopDirectory, 1).firstObject().absoluteString().\
             UTF8String()
 
 

--- a/plyer/platforms/ios/storagepath.py
+++ b/plyer/platforms/ios/storagepath.py
@@ -16,7 +16,6 @@ NSDownloadsDirectory = 15
 NSMoviesDirectory = 17
 NSMusicDirectory = 18
 NSPicturesDirectory = 19
-NSDesktopDirectory = 12
 
 
 class iOSStoragePath(StoragePath):
@@ -58,10 +57,6 @@ class iOSStoragePath(StoragePath):
             NSApplicationDirectory, 1).firstObject().absoluteString.\
             UTF8String()
 
-    def _get_desktop_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDesktopDirectory, 1).firstObject().absoluteString().\
-            UTF8String()
 
 
 def instance():

--- a/plyer/platforms/macosx/storagepath.py
+++ b/plyer/platforms/macosx/storagepath.py
@@ -15,6 +15,8 @@ NSDownloadsDirectory = 15
 NSMoviesDirectory = 17
 NSMusicDirectory = 18
 NSPicturesDirectory = 19
+NSDesktopDirectory = 12
+
 
 
 class OSXStoragePath(StoragePath):
@@ -57,6 +59,14 @@ class OSXStoragePath(StoragePath):
             NSApplicationDirectory, 1
         ).firstObject().absoluteString.UTF8String()
 
+    def _get_desktop_dir(self):
+        return self.defaultManager.URLsForDirectory_inDomains_(
+            NSDesktopDirectory, 1).firstObject().absoluteString.\
+            UTF8String()
+
+    
+    
+    
 
 def instance():
     return OSXStoragePath()

--- a/plyer/tests/test_storagepath.py
+++ b/plyer/tests/test_storagepath.py
@@ -41,6 +41,7 @@ class TestStoragePath(unittest.TestCase):
         self.assertIn(path_format, storagepath.get_music_dir())
         self.assertIn(path_format, storagepath.get_pictures_dir())
         self.assertIn(path_format, storagepath.get_application_dir())
+        self.assertIn(path_format, storagepath.get_desktop_dir())
 
     @PlatformTest('win')
     def test_storagepath_windows(self):


### PR DESCRIPTION
This pull request introduces a new feature to return the macOS desktop path for use in the StoragePath module. This addition allows access to the user's desktop directory on macOS systems, improves cross-platform compatibility, and simplifies file operations related to the OSX.

Key changes:

Added a new function _get_desktop_dir() to retrieve the desktop path on macOS
Added the get_desktop_dir() to the StoragePath facade
Added a line in the test_storagepath.py to test whether it works as intented

Please review and let me know if any further modifications are needed.