### PR TITLE
Migrate from `distutils` to `shutil` for finding executables

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -4,7 +4,7 @@ Linux file chooser
 '''
 
 from plyer.facades import FileChooser
-from distutils.spawn import find_executable as which
+from shutil import which
 import os
 import subprocess as sp
 import time


### PR DESCRIPTION
[`distutils` is not included in newer python versions](https://docs.python.org/3.11/whatsnew/3.10.html#distutils-deprecated), in python `3.12` it throws `ImportError`, so it is good to migrate to `shutil`

> The entire distutils package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages setuptools and packaging, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3.11/library/platform.html#module-platform), [shutil](https://docs.python.org/3.11/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3.11/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3.11/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.