### PR TITLE
remove unsupported options for Zenity

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -106,8 +106,7 @@ class ZenityFileChooser(SubprocessFileChooser):
     def _gen_cmdline(self):
         cmdline = [
             which(self.executable),
-            "--file-selection",
-            "--confirm-overwrite"
+            "--file-selection"
         ]
         if self.multiple:
             cmdline += ["--multiple"]
@@ -117,10 +116,6 @@ class ZenityFileChooser(SubprocessFileChooser):
             cmdline += ["--directory"]
         if self.path:
             cmdline += ["--filename", self.path]
-        if self.title:
-            cmdline += ["--name", self.title]
-        if self.icon:
-            cmdline += ["--window-icon", self.icon]
         for f in self.filters:
             if isinstance(f, str):
                 cmdline += ["--file-filter", f]


### PR DESCRIPTION
Resolves #821 

* --file-selection is now obsolete
* --name option in zenity file chooser was abruptly dropped starting in Ubuntu 24 (which prompted this PR)
* --window-icon option was dropped (unknown when, but would also cause it to fail)

```
/usr/bin/zenity --help-file-selection
Usage:
  zenity [OPTION…]

File selection options
  --file-selection                                  Display file selection dialog
  --filename=FILENAME                               Set the filename
  --multiple                                        Allow multiple files to be selected
  --directory                                       Activate directory-only selection
  --save                                            Activate save mode
  --separator=SEPARATOR                             Set output separator character
  --file-filter=NAME | PATTERN1 PATTERN2 ...        Set a filename filter
  --confirm-overwrite                               DEPRECATED; does nothin
```