### PR TITLE
Update linux/battery module to support both BAT0 and BAT1

### DIFF
--- a/plyer/platforms/linux/battery.py
+++ b/plyer/platforms/linux/battery.py
@@ -19,7 +19,21 @@ class LinuxBattery(Battery):
     def _get_state(self):
         status = {"isCharging": None, "percentage": None}
 
-        kernel_bat_path = join('/sys', 'class', 'power_supply', 'BAT0')
+        # Try BAT0 first, then BAT1
+        bat_names = ['BAT0', 'BAT1']
+        kernel_bat_path = None
+
+        for bat_name in bat_names:
+            path = join('/sys', 'class', 'power_supply', bat_name)
+            if exists(path):
+                kernel_bat_path = path
+                self.battery_name = bat_name
+                break
+        
+        # If no battery found, return empty status, might need to be implemented
+        if not kernel_bat_path:
+            return status
+
         uevent = join(kernel_bat_path, 'uevent')
 
         with open(uevent) as fle:
@@ -54,16 +68,22 @@ class UPowerBattery(Battery):
         environ['LANG'] = 'C'
         status = {"isCharging": None, "percentage": None}
 
-        # We are supporting only one battery now
-        # this will fail if there is no object with such path,
-        # however it's safer than 'upower -d' which provides
-        # multiple unrelated 'state' and 'percentage' keywords
-        dev = "/org/freedesktop/UPower/devices/battery_BAT0"
-        upower_process = Popen(
-            ["upower", "--show-info", dev],
-            stdout=PIPE
-        )
-        output = upower_process.communicate()[0].decode()
+        # Try BAT0 first, then BAT1
+        bat_names = ['BAT0', 'BAT1']
+        output = None
+
+        for bat_name in bat_names:
+            dev = f"/org/freedesktop/UPower/devices/battery_{bat_name}"
+            upower_process = Popen(
+                ["upower", "--show-info", dev],
+                stdout=PIPE
+            )
+            result = upower_process.communicate()[0].decode()
+            if result and "should be ignored" not in result.lower():
+                output = result
+                self.battery_name = bat_name
+                break
+            
         environ['LANG'] = old_lang
         if not output:
             return status
@@ -96,7 +116,9 @@ def instance():
     if whereis_exe('upower'):
         return UPowerBattery()
     sys.stderr.write("upower not found.")
-
-    if exists(join('/sys', 'class', 'power_supply', 'BAT0')):
+    
+    # Check if either BAT0 or BAT1 exists
+    bat_paths = [join('/sys', 'class', 'power_supply', bat) for bat in ['BAT0', 'BAT1']]
+    if any(exists(path) for path in bat_paths):
         return LinuxBattery()
     return Battery()

--- a/plyer/tests/test_battery.py
+++ b/plyer/tests/test_battery.py
@@ -13,7 +13,7 @@ import unittest
 from io import BytesIO
 from os.path import join
 from textwrap import dedent
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 from plyer.tests.common import PlatformTest, platform_import
 
@@ -66,6 +66,42 @@ class MockedKernelSysclass:
         '''
         return BytesIO(dedent(b'''\
             POWER_SUPPLY_NAME=BAT0
+            POWER_SUPPLY_STATUS={}
+            POWER_SUPPLY_PRESENT=1
+            POWER_SUPPLY_TECHNOLOGY=Li-ion
+            POWER_SUPPLY_CYCLE_COUNT=0
+            POWER_SUPPLY_VOLTAGE_MIN_DESIGN=10800000
+            POWER_SUPPLY_VOLTAGE_NOW=12074000
+            POWER_SUPPLY_CURRENT_NOW=1584000
+            POWER_SUPPLY_CHARGE_FULL_DESIGN=5800000
+            POWER_SUPPLY_CHARGE_FULL={}
+            POWER_SUPPLY_CHARGE_NOW={}
+            POWER_SUPPLY_CAPACITY={}
+            POWER_SUPPLY_CAPACITY_LEVEL=Normal
+            POWER_SUPPLY_MODEL_NAME=1005HA
+            POWER_SUPPLY_MANUFACTURER=ASUS
+            POWER_SUPPLY_SERIAL_NUMBER=0
+        '''.decode('utf-8').format(
+            self.charging, self.full,
+            self.now, int(self.percentage)
+        )).encode('utf-8'))
+
+
+class MockedKernelSysClassBAT1(MockedKernelSysclass):
+    @property
+    def path(self):
+        '''
+        Mocked path to Linux kernel sysclass.
+        '''
+        return join('/sys', 'class', 'power_supply', 'BAT1')
+
+    @property
+    def uevent(self):
+        '''
+        Mocked /sys/class/power_supply/BAT0 file.
+        '''
+        return BytesIO(dedent(b'''\
+            POWER_SUPPLY_NAME=BAT1
             POWER_SUPPLY_STATUS={}
             POWER_SUPPLY_PRESENT=1
             POWER_SUPPLY_TECHNOLOGY=Li-ion
@@ -317,43 +353,71 @@ class TestBattery(unittest.TestCase):
 
     def test_battery_linux_kernel(self):
         '''
-        Test mocked Linux kernel sysclass for plyer.battery.
+        Test mocked Linux kernel sysclass for plyer.battery for BAT0 and BAT1
         '''
 
         def false(*args, **kwargs):
             return False
 
-        sysclass = MockedKernelSysclass()
+        sysclass_bat1 = MockedKernelSysClassBAT1()
+        sysclass_bat1.values = {
+            u'Device': u'/org/freedesktop/UPower/devices/battery_BAT1',
+            u'native-path': u'BAT1',
+            u'vendor': u'ASUS',
+            u'model': u'1005HA',
+            u'power supply': u'yes',
+            u'updated': u'Thu 05 Jul 2018 23:15:01 PM CEST',
+            u'has history': u'yes',
+            u'has statistics': u'yes',
+            u'battery': {
+                u'present': u'yes',
+                u'rechargeable': u'yes',
+                u'state': u'discharging',
+                u'warning-level': u'none',
+                u'energy': u'48,708 Wh',
+                u'energy-empty': u'0 Wh',
+                u'energy-full': u'54,216 Wh',
+                u'energy-full-design': u'62,64 Wh',
+                u'energy-rate': u'7,722 W',
+                u'voltage': u'11,916 V',
+                u'time to empty': u'6,3 hours',
+                u'percentage': u'89%',
+                u'capacity': u'86,5517%',
+                u'technology': u'lithium-ion',
+                u'icon-name': u"'battery-full-symbolic"
+            },
+            u'History (charge)': u'1530959637  89,000  discharging',
+            u'History (rate)': u'1530958556  7,474   discharging'
+        }
 
-        with patch(target='os.path.exists') as bat_path:
-            # first call to trigger exists() call
-            platform_import(
-                platform='linux',
-                module_name='battery',
-                whereis_exe=false
-            ).instance()
-            bat_path.assert_called_once_with(sysclass.path)
+        for battery_name, sysclass_mock in [
+            ('BAT0', MockedKernelSysclass()),
+            ('BAT1', sysclass_bat1)
+        ]:
+            with self.subTest(battery_name=battery_name):
+                def false(*args, **kwargs):
+                    return False
 
-            # exists() checked with sysclass path
-            # set mock to proceed with this branch
-            bat_path.return_value = True
+                # Decide if path exists based on battery_name
+                def exists(path):
+                    return battery_name in path
 
-            battery = platform_import(
-                platform='linux',
-                module_name='battery',
-                whereis_exe=false
-            ).instance()
+                with patch('os.path.exists', side_effect=exists) as bat_path:
+                    battery = platform_import(
+                        platform='linux',
+                        module_name='battery',
+                        whereis_exe=false
+                    ).instance()
 
-        stub = Mock(return_value=sysclass.uevent)
-        target = 'builtins.open'
-
-        with patch(target=target, new=stub):
-            self.assertEqual(
-                battery.status, {
-                    'isCharging': sysclass.charging == 'Charging',
-                    'percentage': sysclass.percentage
-                }
-            )
+                stub = Mock(return_value=sysclass_mock.uevent)
+                with patch('builtins.open', new=stub):
+                    self.assertEqual(
+                        battery.status,
+                        {
+                            'isCharging': sysclass_mock.charging == 'Charging',
+                            'percentage': sysclass_mock.percentage
+                        }
+                    )
 
     @PlatformTest('win')
     def test_battery_win(self):


### PR DESCRIPTION
# Update linux/battery module to support both BAT0 and BAT1

## Description

This PR added support for **BAT1** in the linux battery module. For some linux dirstros, such as Arch Linux (which I run) the battery for certain laptop can be **BAT1**, instead of **BAT0** which `plyer` already supported.

This PR will make `plyer` battery module work for every linux distribution. Fixing the error I asked to reopen and now Closes #743.

## Related Issue(s)

- Related to #743 
There might be other issues closed, like this past one but not resolved.

## Changes

- Updated linux/battery module to support **BAT1**.
- Refactored conflicting code in `plyer/tests/test_battery.py`, which was running `assert_called_once_with()` and added testing for both **BAT0** and **BAT1**. N.B.: I didn't understand why had to make sure it was called once, please refactor or lemme know.

## How Has This Been Tested?

- Ran all unit tests using `pytest` and confirmed they passed, but `TestUniqueID.test_uniqueid` which was failing beforehand.
- Performed manual testing on Linux to verify  BAT1 work as expected. **Need somebody to manually test on a Linux system with BAT0**

## Screenshots

![plyer-bat1](https://github.com/user-attachments/assets/a8aade34-5eae-4736-90b4-77bdf24ca442)


## Checklist

- [x] My code follows the project's style guidelines, I hooked PEP8 before committing.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] Change documentation is not needed as it doesn't specify the if the battery is **BAT0** or **BAT1**
- [x] My changes generate no new warnings.
- [x] I have added tests to prove my fix or feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Notes

The only concern is that I had to change the previous test as it required for the battery to only be called once (I don't understand why), the command is one call already.
However, if there is a reason behind it, this my port breaking changes. Please @KeyWeeUsr, let me know if the check for one call is mandatory.