### PR TITLE
Add consistent MIME type parser for Zenity file chooser

### DIFF
--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -139,13 +139,13 @@ class ZenityFileChooser(SubprocessFileChooser):
             cmdline += ["--icon", self.icon]
 
         # Checking if using mime pattern, and exists in dict # ['image','video']
-        self.selected_mime_type = self.filters[0] if isinstance(self.filters, list) and len(self.filters) else ""
+        filters_exist = isinstance(self.filters, list) and len(self.filters)
+        filter_str = self._build_zenity_filter_string(self.filters) if filters_exist else None
 
-        if (
-            not self.selected_mime_type
-            or not isinstance(self.selected_mime_type, str)
-            or self.selected_mime_type not in self.mime_type
-        ):
+        # Use MIME-based filter if available Or else fallback to original
+        if filter_str:
+            cmdline += ["--file-filter", filter_str]
+        elif filters_exist:
             for f in self.filters:
                 if isinstance(f, str):
                     cmdline += ["--file-filter", f]
@@ -154,12 +154,6 @@ class ZenityFileChooser(SubprocessFileChooser):
                         "--file-filter",
                         "{name} | {flt}".format(name=f[0], flt=" ".join(f[1:]))
                     ]
-        else:
-            # Get specifc label with types
-            filter_str = self._build_zenity_filter_string(self.filters)
-            if filter_str:
-                cmdline += ["--file-filter", filter_str]
-
         return cmdline
 
     def _build_zenity_filter_string(self, user_types):

--- a/plyer/platforms/linux/filechooser.py
+++ b/plyer/platforms/linux/filechooser.py
@@ -8,7 +8,7 @@ from shutil import which
 import os
 import subprocess as sp
 import time
-
+import mimetypes
 
 class SubprocessFileChooser:
     '''A file chooser implementation that allows using
@@ -103,6 +103,23 @@ class ZenityFileChooser(SubprocessFileChooser):
     separator = "|"
     successretcode = 0
 
+    mime_type = {
+        "doc": "application/msword",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "ppt": "application/vnd.ms-powerpoint",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "xls": "application/vnd.ms-excel",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "pdf": "application/pdf",
+        "zip": "application/zip",
+
+        "text": "text/",
+        "image": "image/",
+        "video": "video/",
+        "audio": "audio/",
+        "application": "application/",
+    }
+
     def _gen_cmdline(self):
         cmdline = [
             which(self.executable),
@@ -120,15 +137,62 @@ class ZenityFileChooser(SubprocessFileChooser):
             cmdline += ["--filename", self.path]
         if self.icon:
             cmdline += ["--icon", self.icon]
-        for f in self.filters:
-            if isinstance(f, str):
-                cmdline += ["--file-filter", f]
-            else:
-                cmdline += [
-                    "--file-filter",
-                    "{name} | {flt}".format(name=f[0], flt=" ".join(f[1:]))
-                ]
+
+        # Checking if using mime pattern, and exists in dict # ['image','video']
+        self.selected_mime_type = self.filters[0] if isinstance(self.filters, list) and len(self.filters) else ""
+
+        if (
+            not self.selected_mime_type
+            or not isinstance(self.selected_mime_type, str)
+            or self.selected_mime_type not in self.mime_type
+        ):
+            for f in self.filters:
+                if isinstance(f, str):
+                    cmdline += ["--file-filter", f]
+                else:
+                    cmdline += [
+                        "--file-filter",
+                        "{name} | {flt}".format(name=f[0], flt=" ".join(f[1:]))
+                    ]
+        else:
+            # Get specifc label with types
+            filter_str = self._build_zenity_filter_string(self.filters)
+            if filter_str:
+                cmdline += ["--file-filter", filter_str]
+
         return cmdline
+
+    def _build_zenity_filter_string(self, user_types):
+        """
+        For getting Zenity file filter with Readable Label
+
+        :param user_types: List of logical file types like ["image", "pdf", "docx"]
+        :return: Zenity filter string in the form "Label | *.ext *.ext" or None if no matching extensions
+        """
+        matching_extensions = set()
+        filter_label = "Files"  # Default label if no type matches
+
+        for file_type in user_types:
+            mime_pattern = self.mime_type.get(file_type)
+            if not mime_pattern:
+                continue
+
+            # When category like "image/", "text/", "video/" passed in
+            if mime_pattern.endswith("/"):
+                for ext, mapped_mime in mimetypes.types_map.items():
+                    if mapped_mime.startswith(mime_pattern):
+                        matching_extensions.add(ext)
+                filter_label = file_type.capitalize()
+            else:  # Exact MIME type like "application/pdf"
+                matching_extensions.update(mimetypes.guess_all_extensions(mime_pattern))
+                filter_label = file_type.capitalize()
+
+        if not matching_extensions:
+            return None
+
+        # Zenity expects: "Label | *.ext *.ext ..."
+        patterns = [f"*{ext.lstrip('.')}" for ext in sorted(matching_extensions)]
+        return f"{filter_label} | {' '.join(patterns)}"
 
 
 class KDialogFileChooser(SubprocessFileChooser):


### PR DESCRIPTION
### Description:
This PR introduces a consistent MIME type parser for the Zenity-based `FileChooser` on Linux. It ensures that logical file types such as `["image", "video", "pdf"]` are correctly converted into Zenity `--file-filter` patterns.

### Changes included:

- Added a mime_type dictionary mapping logical file types to MIME patterns.

- New import `mimetypes` available on python since `version 2`

- Implemented _build_zenity_filter_string() to automatically generate Zenity-compatible filter strings.

- Updated _gen_cmdline() in ZenityFileChooser to use the new parser.

- Maintains fallback behavior for unknown filters, ensuring backwards compatibility.

### Motivation
It's ensures consistency in `filechooser`  when using
```python
from `from plyer import filechooser`
filechooser.open_file(on_selection=my_fun,filters=["image"], multiple=True)
```
Previously, this pattern worked on Android but on Linux it didn’t show any files. With this change, developers get consistent behavior across platforms without having to manually check the OS.