### PR TITLE
:green_heart: Fix CI failures

### DIFF
--- a/plyer/facades/orientation.py
+++ b/plyer/facades/orientation.py
@@ -42,7 +42,7 @@ class Orientation:
 
     def get_orientation(self) -> str:
         '''
-        Return current screen rotation (landscape, landscape-reversed, portrait, portrait-reversed, unknown)
+        Return current screen rotation.
         '''
         return self._get_landscape()
 

--- a/plyer/platforms/android/devicename.py
+++ b/plyer/platforms/android/devicename.py
@@ -27,7 +27,9 @@ class AndroidDeviceName(DeviceName):
         SettingsGlobal = autoclass('android.provider.Settings$Global')
 
         context = PythonActivity.mActivity
-        name = SettingsGlobal.getString(context.getContentResolver(), SettingsGlobal.DEVICE_NAME)
+        name = SettingsGlobal.getString(
+            context.getContentResolver(), SettingsGlobal.DEVICE_NAME
+        )
 
         if not name:
             name = Build.MODEL

--- a/plyer/platforms/android/keystore.py
+++ b/plyer/platforms/android/keystore.py
@@ -65,22 +65,32 @@ class AndroidKeystore(Keystore):
     def get_secret_key(servicename):
         KeyProperties = autoclass('android.security.keystore.KeyProperties')
         KeyGenerator = autoclass('javax.crypto.KeyGenerator')
-        KeyGenParameterSpec = autoclass('android.security.keystore.KeyGenParameterSpec$Builder')
+        KeyGenParameterSpec = autoclass(
+            'android.security.keystore.KeyGenParameterSpec$Builder'
+        )
         KeyStore = autoclass('java.security.KeyStore')
 
         key_store = KeyStore.getInstance("AndroidKeyStore")
         key_store.load(None)
 
         if not key_store.containsAlias(servicename):
-            builder = KeyGenParameterSpec(servicename,
-                                        KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+            purpose = (
+                KeyProperties.PURPOSE_ENCRYPT |
+                KeyProperties.PURPOSE_DECRYPT
+            )
+            builder = KeyGenParameterSpec(servicename, purpose)
             builder.setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-            builder.setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            key_gen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+            builder.setEncryptionPaddings(
+                KeyProperties.ENCRYPTION_PADDING_NONE
+            )
+            key_gen = KeyGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore"
+            )
             key_gen.init(builder.build())
             key_gen.generateKey()
 
         return key_store.getKey(servicename, None)
+
 
 def instance():
     return AndroidKeystore()

--- a/plyer/platforms/android/orientation.py
+++ b/plyer/platforms/android/orientation.py
@@ -47,7 +47,9 @@ class AndroidOrientation(Orientation):
             Surface.ROTATION_270: 'landscape-reversed',
         }
 
-        rotation = activity.getWindowManager().getDefaultDisplay().getRotation()
+        rotation = (
+            activity.getWindowManager().getDefaultDisplay().getRotation()
+        )
 
         return orientations.get(rotation, 'unknown')
 

--- a/plyer/platforms/linux/orientation.py
+++ b/plyer/platforms/linux/orientation.py
@@ -30,8 +30,12 @@ class LinuxOrientation(Orientation):
         self.screen = self.screen.decode('utf-8').split('\n')[0]
 
         try:
+            command = (
+                f"xrandr -q --verbose | grep {self.screen} | "
+                "sed 's/primary //' | awk '{print $5}'"
+            )
             orientation = sb.check_output(
-                f"xrandr -q --verbose | grep {self.screen} | sed 's/primary //' | awk '{{print $5}}'",
+                command,
                 shell=True
             ).decode('utf-8').strip()
         except Exception:

--- a/plyer/platforms/linux/wifi.py
+++ b/plyer/platforms/linux/wifi.py
@@ -120,7 +120,10 @@ class NMCLIWifi(Wifi):
             self._enable()
 
         ssid = None
-        ssid_proc = Popen(['nmcli', '-t', '-f', 'ACTIVE,NAME', 'connection'], stdout=PIPE)
+        ssid_proc = Popen(
+            ['nmcli', '-t', '-f', 'ACTIVE,NAME', 'connection'],
+            stdout=PIPE
+        )
         ssid_lines = ssid_proc.communicate()[0].decode('utf-8').splitlines()
         for ssid_line in ssid_lines:
             active, ssid_value = ssid_line.split(':')
@@ -379,7 +382,10 @@ class LinuxWifi(Wifi):
             self._enable()
 
         ssid = None
-        ssid_proc = Popen(['nmcli', '-t', '-f', 'ACTIVE,NAME', 'connection'], stdout=PIPE)
+        ssid_proc = Popen(
+            ['nmcli', '-t', '-f', 'ACTIVE,NAME', 'connection'],
+            stdout=PIPE
+        )
         ssid_lines = ssid_proc.communicate()[0].decode('utf-8').splitlines()
         for ssid_line in ssid_lines:
             active, ssid_value = ssid_line.split(':')

--- a/plyer/platforms/macosx/gps.py
+++ b/plyer/platforms/macosx/gps.py
@@ -40,12 +40,16 @@ class OSXGPS(GPS):
         while self._run_loop_thread_allow:
             if self._is_running:
                 next_date = NSDate.dateWithTimeIntervalSinceNow_(0.01)
-                self._run_loop.runMode_beforeDate_('NSDefaultRunLoopMode', next_date)
+                self._run_loop.runMode_beforeDate_(
+                    'NSDefaultRunLoopMode', next_date
+                )
             time.sleep(0.1)
 
     def _start(self, **kwargs):
         if not hasattr(self, '_location_manager'):
-            self.on_status('provider-disabled', 'standard-macos-provider: denied')
+            self.on_status(
+                'provider-disabled', 'standard-macos-provider: denied'
+            )
             return
 
         min_distance = kwargs.get('minDistance')
@@ -53,7 +57,9 @@ class OSXGPS(GPS):
 
         if self._location_manager.authorizationStatus == 2:
             if self.on_status:
-                self.on_status('provider-disabled', 'standard-macos-provider: denied')
+                self.on_status(
+                    'provider-disabled', 'standard-macos-provider: denied'
+                )
 
         self._location_manager.startUpdatingLocation()
         self._is_running = True

--- a/plyer/platforms/macosx/wifi.py
+++ b/plyer/platforms/macosx/wifi.py
@@ -110,9 +110,10 @@ class OSXWifi(Wifi):
             for i in range(cnt):
                 if scan.allObjects().objectAtIndex_(i).ssid is not None:
                     try:
+                        network = scan.allObjects().objectAtIndex_(i)
                         self.names[
-                            scan.allObjects().objectAtIndex_(i).ssid.UTF8String()
-                        ] = scan.allObjects().objectAtIndex_(i)
+                            network.ssid.UTF8String()
+                        ] = network
                     except Exception:
                         pass
         else:

--- a/plyer/platforms/win/libs/wifi_defs.py
+++ b/plyer/platforms/win/libs/wifi_defs.py
@@ -290,7 +290,6 @@ def _connect(network, parameters):
     '''
     Attempts to connect to a specific network.
     '''
-    global _dict
     wireless_interface = _dict[network]
 
     wcp = WLAN_CONNECTION_PARAMETERS()
@@ -480,9 +479,6 @@ def _get_network_info(name):
     '''
     returns the list of the network selected in a dict.
     '''
-    global available
-    global _dict
-
     net = _dict[name]
     dot11BssType = net.dot11BssType
     dot11DefaultAuthAlgorithm = net.dot11DefaultAuthAlgorithm
@@ -505,7 +501,6 @@ def _make_dict():
     '''
     Prepares a dict so it could store network information.
     '''
-    global available
     global _dict
     _dict = {}
     for network in available:
@@ -516,7 +511,6 @@ def _get_available_wifi():
     '''
     returns the available wifi networks.
     '''
-    global _dict
     return _dict
 
 

--- a/plyer/tests/test_devicename.py
+++ b/plyer/tests/test_devicename.py
@@ -65,9 +65,22 @@ class TestDeviceName(unittest.TestCase):
                                      )
         devicename_instance = devicename.instance()
 
-        with patch.object(socket,
-                          'gethostname',
-                          return_value='mocked_macosx_hostname'
+        class LocalizedName:
+            @staticmethod
+            def UTF8String():
+                return 'mocked_macosx_hostname'
+
+        class CurrentHost:
+            localizedName = LocalizedName()
+
+        class NSHost:
+            @staticmethod
+            def currentHost():
+                return CurrentHost()
+
+        with patch.object(devicename,
+                          'autoclass',
+                          return_value=NSHost
                           ) as _:
 
             evaluated_device_name = devicename_instance.device_name


### PR DESCRIPTION
Resolve flake8 failures introduced in #836 by wrapping long lines, fixing continuation indentation, restoring expected module spacing, and removing unused global declarations.

Update the macOS devicename test to mock the new NSHost-based implementation instead of socket.gethostname(), matching the code path now used by the platform implementation.