### PR TITLE
fix-proxy-fallback-warning

### DIFF
--- a/plyer/utils.py
+++ b/plyer/utils.py
@@ -89,15 +89,41 @@ class Proxy:
         if obj:
             return obj
         # do the import
+        name = object.__getattribute__(self, '_name')
         try:
-            name = object.__getattribute__(self, '_name')
             module = 'plyer.platforms.{}.{}'.format(
                 platform, name)
             mod = __import__(module, fromlist='.')
             obj = mod.instance()
-        except Exception:
-            import traceback
-            traceback.print_exc()
+        except Exception as exc:
+            # Loading the platform-specific backend can fail for many
+            # legitimate reasons (an optional native dependency such as
+            # pywin32, PyJNIus or pyobjus is missing, misconfigured, or not
+            # supported on this OS version). Previously this printed a full
+            # raw traceback for *every* such failure, which looked like a
+            # crash even though Plyer was already falling back gracefully -
+            # see e.g. GitHub issues #843, #830 and #826. We now emit one
+            # short, actionable warning instead, and only print the full
+            # traceback when the developer explicitly opts in.
+            warning_message = (
+                "plyer: could not load the '{name}' backend for the "
+                "'{platform}' platform ({exc_type}: {exc}). Falling back "
+                "to the base facade; calls to plyer.{name} will raise "
+                "NotImplementedError. Set the PLYER_DEBUG_TRACEBACK "
+                "environment variable to see the full traceback.".format(
+                    name=name,
+                    platform=platform,
+                    exc_type=type(exc).__name__,
+                    exc=exc,
+                )
+            )
+            import warnings
+            warnings.warn(warning_message, RuntimeWarning, stacklevel=2)
+
+            if environ.get('PLYER_DEBUG_TRACEBACK'):
+                import traceback
+                traceback.print_exc()
+
             facade = object.__getattribute__(self, '_facade')
             obj = facade()
 


### PR DESCRIPTION
Fixes #843

## Problem
When Proxy._ensure_obj() fails to import a platform-specific backend
(e.g. an optional native dependency like pywin32, PyJNIus, or pyobjus
is missing or misconfigured), it silently falls back to the base
facade, but not before calling traceback.print_exc(), which dumps a
full raw stack trace to the console. This looks like a crash even
though Plyer is already handling it gracefully. The same symptom
shows up in several other open issues (#830, #826, #844).

## Fix
Replace the unconditional traceback.print_exc() with a single,
readable warnings.warn() message that names the feature, the
platform, and the underlying exception, and explains what happens
next (calls will raise NotImplementedError). The full traceback is
still available on request via a new PLYER_DEBUG_TRACEBACK
environment variable, so no diagnostic information is lost.

## Compatibility
- No new dependencies (uses the stdlib `warnings` module, already
  imported elsewhere in this file).
- The success path (backend import works) is completely unchanged.
- Fully backward compatible — this only changes what gets printed
  when a backend fails to load.

## Testing
Verified manually with a standalone reproduction script that
simulates a missing backend module (no native dependencies
required): confirms the fallback still works, exactly one warning
is shown, and PLYER_DEBUG_TRACEBACK=1 still prints the full
traceback for debugging.