### PR TITLE
Fix NSString.UTF8String to decode bytes

### DIFF
--- a/plyer/platforms/ios/storagepath.py
+++ b/plyer/platforms/ios/storagepath.py
@@ -18,6 +18,12 @@ NSMusicDirectory = 18
 NSPicturesDirectory = 19
 
 
+def _nsstring_to_str(value):
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    return value
+
+
 class iOSStoragePath(StoragePath):
 
     def __init__(self):
@@ -33,29 +39,46 @@ class iOSStoragePath(StoragePath):
         return 'This feature is not implemented for this platform.'
 
     def _get_documents_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDocumentDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSDocumentDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_downloads_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDownloadsDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSDownloadsDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_videos_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSMoviesDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSMoviesDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_music_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSMusicDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSMusicDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_pictures_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSPicturesDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSPicturesDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_application_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSApplicationDirectory, 1).firstObject().absoluteString.\
-            UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSApplicationDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
 
 def instance():

--- a/plyer/platforms/macosx/storagepath.py
+++ b/plyer/platforms/macosx/storagepath.py
@@ -18,6 +18,12 @@ NSPicturesDirectory = 19
 NSDesktopDirectory = 12
 
 
+def _nsstring_to_str(value):
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    return value
+
+
 class OSXStoragePath(StoragePath):
 
     def __init__(self):
@@ -25,7 +31,7 @@ class OSXStoragePath(StoragePath):
 
     def _get_home_dir(self):
         home_dir_NSURL = self.defaultManager.homeDirectoryForCurrentUser
-        return home_dir_NSURL.absoluteString.UTF8String()
+        return _nsstring_to_str(home_dir_NSURL.absoluteString.UTF8String())
 
     def _get_external_storage_dir(self):
         return 'Method not implemented for current platform.'
@@ -34,34 +40,53 @@ class OSXStoragePath(StoragePath):
         return '/'
 
     def _get_documents_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDocumentDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSDocumentDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_downloads_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDownloadsDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSDownloadsDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_videos_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSMoviesDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSMoviesDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_music_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSMusicDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSMusicDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_pictures_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSPicturesDirectory, 1).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSPicturesDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_application_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSApplicationDirectory, 1
-        ).firstObject().absoluteString.UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSApplicationDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
     def _get_desktop_dir(self):
-        return self.defaultManager.URLsForDirectory_inDomains_(
-            NSDesktopDirectory, 1).firstObject().absoluteString.\
-            UTF8String()
+        return _nsstring_to_str(
+            self.defaultManager.URLsForDirectory_inDomains_(
+                NSDesktopDirectory, 1
+            ).firstObject().absoluteString.UTF8String()
+        )
 
 
 def instance():


### PR DESCRIPTION
On newer wheels (tested on Python 3.14), `NSString.UTF8String()` returns bytes instead of string:

```
======================================================================
ERROR: test_audio_macosx (plyer.tests.test_audio.TestAudio.test_audio_macosx)
Test macOS audio start, stop and play
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dev-account/git/plyer/plyer/tests/test_audio.py", line 46, in test_audio_macosx
    audio = audio.instance()
  File "/Users/dev-account/git/plyer/plyer/platforms/macosx/audio.py", line 90, in instance
    return OSXAudio()
  File "/Users/dev-account/git/plyer/plyer/platforms/macosx/audio.py", line 22, in __init__
    default_path = join(
        OSXStoragePath().get_music_dir(),
        'audio.wav'
    )
  File "<frozen posixpath>", line 90, in join
  File "<frozen genericpath>", line 191, in _check_arg_types
TypeError: Can't mix strings and bytes in path components
```

Decode to string in storagepath if we detect bytes.