### PR TITLE
Fix FileUriExposedException in Android camera capture

### DIFF
--- a/plyer/facades/camera.py
+++ b/plyer/facades/camera.py
@@ -7,6 +7,21 @@ The :class:`Camera` is to capture pictures and make videos.
 .. note::
         - On Android the `CAMERA` , `WRITE_EXTERNAL_STORAGE`,
           `READ_EXTERNAL_STORAGE` permissions are needed.
+        - On Android, filename is handed to the camera app via a
+          FileProvider content:// Uri (required since API 24; a raw
+          file:// Uri raises FileUriExposedException). Your app's
+          manifest must declare a matching FileProvider, authority
+          ``<package name>.fileprovider``, exposing the directory
+          filename lives in. With buildozer this means, in
+          buildozer.spec: ``android.gradle_dependencies =
+          androidx.core:core:<version>``, ``android.enable_androidx
+          = True``, a ``res/xml`` paths file added via
+          ``android.res_xml``, and a ``<provider>`` element added to
+          ``AndroidManifest.xml`` (e.g. via a ``p4a.hook`` -- p4a has
+          no built-in way to inject a manifest element inside
+          ``<application>`` at the time of writing). See Android's
+          FileProvider docs for the paths-file format:
+          https://developer.android.com/reference/androidx/core/content/FileProvider
 
 Simple Examples
 ---------------

--- a/plyer/platforms/android/camera.py
+++ b/plyer/platforms/android/camera.py
@@ -8,7 +8,8 @@ from plyer.platforms.android import activity
 Intent = autoclass('android.content.Intent')
 PythonActivity = autoclass('org.kivy.android.PythonActivity')
 MediaStore = autoclass('android.provider.MediaStore')
-Uri = autoclass('android.net.Uri')
+File = autoclass('java.io.File')
+FileProvider = autoclass('androidx.core.content.FileProvider')
 
 
 class AndroidCamera(Camera):
@@ -20,9 +21,13 @@ class AndroidCamera(Camera):
         android.activity.unbind(on_activity_result=self._on_activity_result)
         android.activity.bind(on_activity_result=self._on_activity_result)
         intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        uri = Uri.parse('file://' + filename)
+        uri = self._get_content_uri(filename)
         parcelable = cast('android.os.Parcelable', uri)
         intent.putExtra(MediaStore.EXTRA_OUTPUT, parcelable)
+        intent.addFlags(
+            Intent.FLAG_GRANT_READ_URI_PERMISSION
+            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        )
         activity.startActivityForResult(intent, 0x123)
 
     def _take_video(self, on_complete, filename=None):
@@ -32,14 +37,34 @@ class AndroidCamera(Camera):
         android.activity.unbind(on_activity_result=self._on_activity_result)
         android.activity.bind(on_activity_result=self._on_activity_result)
         intent = Intent(MediaStore.ACTION_VIDEO_CAPTURE)
-        uri = Uri.parse('file://' + filename)
+        uri = self._get_content_uri(filename)
         parcelable = cast('android.os.Parcelable', uri)
         intent.putExtra(MediaStore.EXTRA_OUTPUT, parcelable)
 
         # 0 = low quality, suitable for MMS messages,
         # 1 = high quality
         intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1)
+        intent.addFlags(
+            Intent.FLAG_GRANT_READ_URI_PERMISSION
+            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        )
         activity.startActivityForResult(intent, 0x123)
+
+    @staticmethod
+    def _get_content_uri(filename):
+        '''
+        Returns a FileProvider content:// Uri for filename instead of a raw
+        file:// Uri. Any app targeting API 24+ that hands another app (here,
+        the camera app) a file:// Uri raises FileUriExposedException -- see
+        https://developer.android.com/reference/android/os/FileUriExposedException.
+        Requires the consuming app to declare a FileProvider in its
+        manifest; see the Camera facade docstring for the required setup.
+        '''
+        activity_context = PythonActivity.mActivity
+        authority = activity_context.getPackageName() + '.fileprovider'
+        return FileProvider.getUriForFile(
+            activity_context, authority, File(filename)
+        )
 
     def _on_activity_result(self, requestCode, resultCode, intent):
         if requestCode != 0x123:


### PR DESCRIPTION
AndroidCamera._take_picture/_take_video pass the camera app a raw file:// Uri via EXTRA_OUTPUT. Any app targeting API 24+ that exposes a file:// Uri to another app crashes with FileUriExposedException (https://developer.android.com/reference/android/os/FileUriExposedException), so calling camera.take_picture()/take_video() on any reasonably current targetSdkVersion currently cannot work at all.

Fixed by resolving a FileProvider content:// Uri for the destination file instead (authority "<package name>.fileprovider", matching the androidx.core.content.FileProvider convention), with read/write grant flags on the intent so the camera app can actually write to it.

This requires the consuming app to declare a FileProvider in its own manifest -- documented in the Camera facade's docstring, along with the buildozer.spec settings needed to wire it up.